### PR TITLE
Add createUser(), removeUser() and authWithPassword()

### DIFF
--- a/lib/src/auth_response.dart
+++ b/lib/src/auth_response.dart
@@ -7,7 +7,7 @@ import 'dart:js';
  */
 class AuthResponse {
   final int expires;
-  final String auth;
+  final JsObject auth;
 
   AuthResponse(JsObject response)
       : expires = response['expires'],

--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -61,6 +61,28 @@ class Firebase extends Query {
   }
 
   /**
+   * Authenticates a Firebase client using an email / password combination.
+   */
+  Future<AuthResponse> authWithPassword(credentials) {
+    var c = new Completer();
+    // On failure, the first argument will be an Error object indicating the
+    // failure. On success, the first argument will be null and the second
+    // will be an object containing { auth: <auth payload>, expires:
+    // <expiration time in seconds since the unix epoch> }.
+    _fb.callMethod('authWithPassword', [credentials, (err, [result]) {
+      if (err != null) {
+        c.completeError(err);
+      } else {
+        c.complete(new AuthResponse(result));
+      }
+    }, (err) {
+      c.completeError(err);
+    }]);
+    return c.future;
+  }
+
+
+  /**
    * Unauthenticates a Firebase client (i.e. logs out).
    */
   void unauth() {
@@ -245,6 +267,28 @@ class Firebase extends Query {
    }
 
    /**
+    * Creates a new user account using an email / password combination.
+    */
+   Future createUser(credentials) {
+     var c = new Completer();
+     _fb.callMethod('createUser', [credentials, (err) {
+       _resolveFuture(c, err, null);
+     }]);
+     return c.future;
+   }
+
+   /**
+    * Removes an existing user account using an email / password combination.
+    */
+   Future removeUser(credentials) {
+     var c = new Completer();
+     _fb.callMethod('removeUser', [credentials, (err) {
+       _resolveFuture(c, err, null);
+     }]);
+     return c.future;
+   }
+
+   /**
     * Resolve a future, given an error and result.
     */
    void _resolveFuture(Completer c, err, res) {
@@ -253,7 +297,7 @@ class Firebase extends Query {
      } else {
        c.complete(res);
      }
-   }
+   }   
 }
 
 /**

--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -297,7 +297,7 @@ class Firebase extends Query {
      } else {
        c.complete(res);
      }
-   }   
+   }
 }
 
 /**

--- a/test/test.dart
+++ b/test/test.dart
@@ -15,7 +15,7 @@ const INVALID_TOKEN = 'xbKOOdkZDBExtKM3sZw6gWtFpGgqMkMidXCiAFjm';
 
 // Update CREDENTAILS_EMAIL to an email address to test
 // auth using email/password credentials
-const CREDENTIALS_EMAIL = 'email@email.com';
+const CREDENTIALS_EMAIL = null;
 const CREDENTIALS_PASSWORD = 'right';
 const CREDENTIALS_WRONG_PASSWORD = 'wrong';
 

--- a/test/test.dart
+++ b/test/test.dart
@@ -5,8 +5,7 @@ import 'package:firebase/firebase.dart';
 import 'package:scheduled_test/scheduled_test.dart';
 import 'package:unittest/html_config.dart';
 
-//const TEST_URL = 'https://dart-test.firebaseio-demo.com/test/';
-const TEST_URL = 'https://resplendent-fire-5447.firebaseio.com/';
+const TEST_URL = 'https://dart-test.firebaseio-demo.com/test/';
 
 // Update TEST_URL to a valid URL and update AUTH_KEY to a corresponding
 // key to test authentication.
@@ -17,7 +16,7 @@ const INVALID_TOKEN = 'xbKOOdkZDBExtKM3sZw6gWtFpGgqMkMidXCiAFjm';
 // auth using email/password credentials.
 // Unfortunately, createUser does not work with the firebaseio demo test URL,
 // if you want to enable this, you will likely need to change TEST_URL to your own.
-const CREDENTIALS_EMAIL = "email@email.com";
+const CREDENTIALS_EMAIL = null;
 const CREDENTIALS_PASSWORD = 'right';
 const CREDENTIALS_WRONG_PASSWORD = 'wrong';
 

--- a/test/test.dart
+++ b/test/test.dart
@@ -5,7 +5,8 @@ import 'package:firebase/firebase.dart';
 import 'package:scheduled_test/scheduled_test.dart';
 import 'package:unittest/html_config.dart';
 
-const TEST_URL = 'https://dart-test.firebaseio-demo.com/test/';
+//const TEST_URL = 'https://dart-test.firebaseio-demo.com/test/';
+const TEST_URL = 'https://resplendent-fire-5447.firebaseio.com/';
 
 // Update TEST_URL to a valid URL and update AUTH_KEY to a corresponding
 // key to test authentication.
@@ -16,7 +17,7 @@ const INVALID_TOKEN = 'xbKOOdkZDBExtKM3sZw6gWtFpGgqMkMidXCiAFjm';
 // auth using email/password credentials.
 // Unfortunately, createUser does not work with the firebaseio demo test URL,
 // if you want to enable this, you will likely need to change TEST_URL to your own.
-const CREDENTIALS_EMAIL = null;
+const CREDENTIALS_EMAIL = "email@email.com";
 const CREDENTIALS_PASSWORD = 'right';
 const CREDENTIALS_WRONG_PASSWORD = 'wrong';
 
@@ -43,7 +44,7 @@ void main() {
   });
 
   if (AUTH_KEY != null) {
-    group('auth-key', () {
+    group('auth', () {
       test('bad auth should fail', () {
         expect(f.auth(INVALID_TOKEN), throwsA((error) {
           expect(error['code'], 'INVALID_TOKEN');
@@ -63,12 +64,12 @@ void main() {
         'password':CREDENTIALS_PASSWORD});
       var badCredentials = new JsObject.jsify({'email':CREDENTIALS_EMAIL, 
         'password':CREDENTIALS_WRONG_PASSWORD});
-            
-      test('credentials', () {
+      
+      test('auth-credentials', () {
         f.createUser(credentials).then((err) { 
           expect(err, null);
           f.authWithPassword(credentials).then((authResponse) { 
-            expect(authResponse.expires, isPositive);
+            expect(authResponse.auth, isNotNull);
             expect(f.authWithPassword(badCredentials), throwsA((error) {
               expect(error['code'], 'INVALID_PASSWORD');
               f.removeUser(credentials).then((err) { expect(err, null); }); 

--- a/test/test.dart
+++ b/test/test.dart
@@ -5,8 +5,7 @@ import 'package:firebase/firebase.dart';
 import 'package:scheduled_test/scheduled_test.dart';
 import 'package:unittest/html_config.dart';
 
-//const TEST_URL = 'https://dart-test.firebaseio-demo.com/test/';
-const TEST_URL = 'https://resplendent-fire-5447.firebaseio.com/';
+const TEST_URL = 'https://dart-test.firebaseio-demo.com/test/';
 
 // Update TEST_URL to a valid URL and update AUTH_KEY to a corresponding
 // key to test authentication.
@@ -14,7 +13,9 @@ const AUTH_KEY = null;
 const INVALID_TOKEN = 'xbKOOdkZDBExtKM3sZw6gWtFpGgqMkMidXCiAFjm';
 
 // Update CREDENTAILS_EMAIL to an email address to test
-// auth using email/password credentials
+// auth using email/password credentials.
+// Unfortunately, createUser does not work with the firebaseio demo test URL,
+// if you want to enable this, you will likely need to change TEST_URL to your own.
 const CREDENTIALS_EMAIL = null;
 const CREDENTIALS_PASSWORD = 'right';
 const CREDENTIALS_WRONG_PASSWORD = 'wrong';


### PR DESCRIPTION
I added createUser(), removeUser() and authWithPassword().

As a consequence of that, I also needed to change AuthResponse.auth to type JsObject rather than String, although perhaps it should just be untyped.

Thoughts?

Also, if I execute async methods within a Dart test, there seems to be no way to wait for completion other than chaining async calls together using .then().  Which is what I do in the auth-credentials test group.  The test seems a bit monolithic, but if I write separate tests for createUser(), removeUser() and authWithPassword(), then there's a race toward failure.

How do you want to see these tests structured?  I would be happy to fix.


