### PR TITLE
Breaking: Update operations to work with latest JS SDK

### DIFF
--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -160,8 +160,8 @@ class Firebase extends Query {
   Future set(value) {
     var c = new Completer();
     value = jsify(value);
-    _fb.callMethod('set', [value, (err, res) {
-      _resolveFuture(c, err, res);
+    _fb.callMethod('set', [value, (err) {
+      _resolveFuture(c, err);
     }]);
     return c.future;
   }
@@ -177,8 +177,8 @@ class Firebase extends Query {
   Future update(Map<String, dynamic> value) {
     var c = new Completer();
     var jsValue = jsify(value);
-    _fb.callMethod('update', [jsValue, (err, res) {
-      _resolveFuture(c, err, res);
+    _fb.callMethod('update', [jsValue, (err) {
+      _resolveFuture(c, err);
     }]);
     return c.future;
   }
@@ -195,8 +195,8 @@ class Firebase extends Query {
    */
   Future remove() {
     var c = new Completer();
-    _fb.callMethod('remove', [(err, res) {
-      _resolveFuture(c, err, res);
+    _fb.callMethod('remove', [(err) {
+      _resolveFuture(c, err);
     }]);
     return c.future;
   }
@@ -226,8 +226,8 @@ class Firebase extends Query {
    Future setWithPriority(value, int priority) {
      var c = new Completer();
      value = jsify(value);
-     _fb.callMethod('setWithPriority', [value, priority, (err, res) {
-       _resolveFuture(c, err, res);
+     _fb.callMethod('setWithPriority', [value, priority, (err) {
+       _resolveFuture(c, err);
      }]);
      return c.future;
    }
@@ -247,8 +247,8 @@ class Firebase extends Query {
     */
    Future setPriority(int priority) {
      var c = new Completer();
-     _fb.callMethod('setPriority', [priority, (err, res) {
-       _resolveFuture(c, err, res);
+     _fb.callMethod('setPriority', [priority, (err) {
+       _resolveFuture(c, err);
      }]);
      return c.future;
    }
@@ -313,7 +313,7 @@ class Firebase extends Query {
    /**
     * Resolve a future, given an error and result.
     */
-   void _resolveFuture(Completer c, err, res) {
+   void _resolveFuture(Completer c, err, [res = null]) {
      if (err != null) {
        c.completeError(err);
      } else {
@@ -361,7 +361,7 @@ class Query {
   Stream<Event> _createStream(String type) {
     StreamController<Event> controller;
     void startListen() {
-      _fb.callMethod('on', [type, (snapshot, prevChild) {
+      _fb.callMethod('on', [type, (snapshot, [prevChild = null]) {
         controller.add(
             new Event(new DataSnapshot.fromJsObject(snapshot), prevChild));
       }]);

--- a/test/test.html
+++ b/test/test.html
@@ -10,7 +10,7 @@
   </head>
 
   <body>
-    <script src="https://cdn.firebase.com/js/client/1.1.2/firebase.js"></script>
+    <script src="https://cdn.firebase.com/js/client/2.1.1/firebase.js"></script>
     <script type="application/dart" src="test.dart"></script>
     <script src="packages/browser/dart.js"></script>
   </body>


### PR DESCRIPTION
This is WIP but right now is 100% passing when using latest JS lib. Fixes #20 

I need another pair of eyes who is more familiar with how the JS callbacks work in Firebase, but I wanted to begin discussion.

It seems, for the most part, a lot of the wrapper methods were passing two arguments through the callback when there should only be one. Just grabbing a random method: https://www.firebase.com/docs/web/api/firebase/update.html
`The callback will be passed an Error object on failure; else null.`

I went through the methods and removed the second argument entirely where I saw that there should never be one with the new library. I made the assumption that some of the calls might have one, so `res` now has a default value of `null` when it's going through `_resolveFuture()`.

This fixed everything but the calls using the streams-- for those, it seemed like a similar issue. Sometimes `prevChild` was going through and that was causing problems when there was no second argument. Some `.on()` events have it, some don't, so I went the optional/default route there too. See here: https://www.firebase.com/docs/web/api/query/on.html ("value" event doesn't have it, "child added" does, etc.).

As it is, this is breaking only because you would have to use the latest major version of the JS library. It requires no other code changes otherwise-- tests were untouched.

This still requires some clean-up. Methods would also need fixed in `Disconnect`. There are still a lot of deprecation warnings, etc.

Let me know if I'm also wasting my time and just doing something stupid.