### PR TITLE
Resolve #24 ("Events triggered out-of-order") and add test case.

### DIFF
--- a/test/test.dart
+++ b/test/test.dart
@@ -7,10 +7,10 @@ import 'package:unittest/html_config.dart';
 
 const TEST_URL = 'https://dart-test.firebaseio-demo.com/test/';
 
-// Update TEST_URL to a valid URL and update AUTH_KEY to a corresponding
-// key to test authentication.
-const AUTH_KEY = null;
-const INVALID_TOKEN = 'xbKOOdkZDBExtKM3sZw6gWtFpGgqMkMidXCiAFjm';
+// Update TEST_URL to a valid URL and update AUTH_TOKEN to a corresponding
+// authentication token to test authentication.
+const AUTH_TOKEN = null;
+const INVALID_AUTH_TOKEN = 'xbKOOdkZDBExtKM3sZw6gWtFpGgqMkMidXCiAFjm';
 
 // Update CREDENTAILS_EMAIL to an email address to test
 // auth using email/password credentials.
@@ -42,17 +42,17 @@ void main() {
     });
   });
 
-  if (AUTH_KEY != null) {
+  if (AUTH_TOKEN != null) {
     group('authWithCustomToken', () {
       test('bad auth token should fail', () {
-        expect(f.authWithCustomToken(INVALID_TOKEN), throwsA((error) {
+        expect(f.authWithCustomToken(INVALID_AUTH_TOKEN), throwsA((error) {
           expect(error['code'], 'INVALID_TOKEN');
           return true;
         }));
       });
 
       test('good auth token', () {
-        return f.authWithCustomToken(AUTH_KEY);
+        return f.authWithCustomToken(AUTH_TOKEN);
       });
     });
   }

--- a/test/test.dart
+++ b/test/test.dart
@@ -63,15 +63,15 @@ void main() {
         'password':CREDENTIALS_PASSWORD});
       var badCredentials = new JsObject.jsify({'email':CREDENTIALS_EMAIL, 
         'password':CREDENTIALS_WRONG_PASSWORD});
-      
+
       test('auth-credentials', () {
-        f.createUser(credentials).then((err) { 
+        f.createUser(credentials).then((err) {
           expect(err, null);
-          f.authWithPassword(credentials).then((authResponse) { 
+          f.authWithPassword(credentials).then((authResponse) {
             expect(authResponse.auth, isNotNull);
             expect(f.authWithPassword(badCredentials), throwsA((error) {
               expect(error['code'], 'INVALID_PASSWORD');
-              f.removeUser(credentials).then((err) { expect(err, null); }); 
+              f.removeUser(credentials).then((err) { expect(err, null); });
               return true;
             }));
           });
@@ -292,4 +292,42 @@ void main() {
       });
     });
   });
+
+  group('onDisconnect', () {
+
+    test('set', () {
+      var value = {'onDisconnect set': 1};
+      return f.onDisconnect.set(value).then((v) {
+        // Unable to check value (value set upon disconnect.)
+      });
+    });
+
+    test('setWithPriority', () {
+      var priority = 1;
+      var value = {'onDisconnect setWithPriority': 2};
+      return f.onDisconnect.setWithPriority(value, priority).then((v) {
+        // Unable to check value (value set upon disconnect.)
+      });
+    });
+
+    test('update', () {
+      var value = {'onDisconnect update': 3};
+      return f.onDisconnect.update(value).then((v) {
+        // Unable to check value (value updated upon disconnect.)
+      });
+    });
+
+    test('remove', () {
+      return f.onDisconnect.remove().then((v) {
+        // Unable to check value (value removed upon disconnect.)
+      });
+    });
+
+    test('cancel', () {
+      return f.onDisconnect.cancel().then((v) {
+        // TODO: confirm that queued set/update events are cancelled.
+      });
+    });
+  });
+
 }


### PR DESCRIPTION
The proposed solution to #24 is to set the StreamController constructor's `sync` parameter to `true`, to ensure that events are passed directly to the streams' listeners thereby ensuring that listeners see events in the order that must be guaranteed per the Firebase specification.