### PR TITLE
fix a bracket mismatch in test.dart

### DIFF
--- a/test/test.dart
+++ b/test/test.dart
@@ -316,6 +316,8 @@ void main() {
         else waitFuture.then((_) {
           return testRef.update({'key': 3});
         });
+      });
+    });
 
     test('value events triggered last', () {
       schedule(() {


### PR DESCRIPTION
Very very small addition, I was going to try and implement the `authAnonymously` but this stopped me. 