### PR TITLE
Updated to work with and add methods for Firebase api v2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 * Added changeEmail()
 
+* Added authAnonymously(), authWithOAuthPopup(), authWithOAuthRedirect()
+
+* Added getAuth() and onAuth() listener
+
 * Added orderByChild(), orderByKey(), orderByValue(), orderByPriority()
 
 * Added equalTo(), limitToFirst(), limitToLast()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 0.4.0
+
+* Updated for Firebase api v2.2.2
+
+* Deprecated `name` getter on Firebase and DataSnapshot
+
+* Added `key` getter on Firebase and DataSnapshot, replacing `name`
+
+* Added changeEmail()
+
+* Added orderByChild(), orderByKey(), orderByValue(), orderByPriority()
+
+* Added equalTo(), limitToFirst(), limitToLast()
+
+* Deprecated `limit` on Query object
+
+* Added `exists` getter to DataSnapshot
+
+* Added several tests
+
 ## 0.3.0
 
 * Add createUser(), removeUser() and authWithPassword()

--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ Follow the instructions on the [pub page](http://pub.dartlang.org/packages/fireb
 **The firebase.js library MUST be included for the wrapper to work**:
 
 ```html
-<script src="https://cdn.firebase.com/js/client/1.1.2/firebase.js"></script>
+<script src="https://cdn.firebase.com/js/client/2.2.2/firebase.js"></script>
 ```

--- a/lib/src/data_snapshot.dart
+++ b/lib/src/data_snapshot.dart
@@ -38,8 +38,8 @@ class DataSnapshot {
 
   /**
    * Get a DataSnapshot for the location at the specified relative path. The
-   * relative path can either bve a simple child name or a deeper slash
-   * seperated path.
+   * relative path can either be a simple child name or a deeper slash
+   * separated path.
    */
   DataSnapshot child(String path) =>
       new DataSnapshot.fromJsObject(_ds.callMethod('child', [path]));
@@ -80,7 +80,7 @@ class DataSnapshot {
   int get numChildren => _ds.callMethod('numChildren');
 
   /**
-   * Get the Firebsae reference for the location that generated this
+   * Get the Firebase reference for the location that generated this
    * DataSnapshot.
    */
   Firebase ref() => new Firebase.fromJsObject(_ds.callMethod('ref'));

--- a/lib/src/data_snapshot.dart
+++ b/lib/src/data_snapshot.dart
@@ -26,6 +26,12 @@ class DataSnapshot {
   DataSnapshot.fromJsObject(JsObject obj): _ds = obj;
 
   /**
+   * Returns true if this DataSnapshot contains any data.
+   * It is slightly more efficient than using snapshot.val() !== null.
+   */
+  bool get exists => _ds.callMethod('exists');
+
+  /**
    * Get the Dart Primitive, Map or List representation of the DataSnapshot.
    * The value may be null, indicating that the snapshot is empty and contains
    * no data.
@@ -69,8 +75,14 @@ class DataSnapshot {
   bool get hasChildren => _ds.callMethod('hasChildren');
 
   /**
+   * The key of the location that generated this DataSnapshot.
+   */
+  String get key => _ds.callMethod('key');
+
+  /**
    * The name of the location that generated this DataSnapshot.
    */
+  @deprecated
   String get name => _ds.callMethod('name');
 
   /**

--- a/lib/src/disconnect.dart
+++ b/lib/src/disconnect.dart
@@ -34,8 +34,8 @@ class Disconnect {
   Future set(value) {
     var c = new Completer();
     value = jsify(value);
-    _od.callMethod('set', [value, (err, res) {
-      _resolveFuture(c, err, res);
+    _od.callMethod('set', [value, (err) {
+      _resolveFuture(c, err, null);
     }]);
     return c.future;
   }
@@ -48,8 +48,8 @@ class Disconnect {
   Future setWithPriority(value, priority) {
     var c = new Completer();
     value = jsify(value);
-    _od.callMethod('setWithPriority', [value, priority, (err, res) {
-      _resolveFuture(c, err, res);
+    _od.callMethod('setWithPriority', [value, priority, (err) {
+      _resolveFuture(c, err, null);
     }]);
     return c.future;
   }
@@ -68,8 +68,8 @@ class Disconnect {
   Future update(value) {
     var c = new Completer();
     value = jsify(value);
-    _od.callMethod('update', [value, (err, res) {
-      _resolveFuture(c, err, res);
+    _od.callMethod('update', [value, (err) {
+      _resolveFuture(c, err, null);
     }]);
     return c.future;
   }
@@ -83,8 +83,8 @@ class Disconnect {
    */
   Future remove() {
     var c = new Completer();
-    _od.callMethod('remove', [(err,res) {
-       _resolveFuture(c, err, res);
+    _od.callMethod('remove', [(err) {
+       _resolveFuture(c, err, null);
     }]);
     return c.future;
   }
@@ -99,8 +99,8 @@ class Disconnect {
    */
   Future cancel() {
     var c = new Completer();
-    _od.callMethod('cancel', [(err,res) {
-       _resolveFuture(c, err, res);
+    _od.callMethod('cancel', [(err) {
+       _resolveFuture(c, err, null);
     }]);
     return c.future;
   }

--- a/lib/src/disconnect.dart
+++ b/lib/src/disconnect.dart
@@ -9,8 +9,8 @@ import 'util.dart';
  * The Disconnect class encapsulates all operations to be performed on a
  * Firebase when the client is disconnected. This allows you to write or
  * clear data when your client disconnects from the Firebase servers. These
- * updates occur whether your client disconnectes cleanly or not, so you can
- * rely on them to clean up data efven if a connection is dropped or a client
+ * updates occur whether your client disconnects cleanly or not, so you can
+ * rely on them to clean up data even if a connection is dropped or a client
  * crashes.
  *
  * Note that these functions should be called before any data is written to

--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -547,6 +547,18 @@ class Query {
   }
 
   /**
+   * Generates a new Query object limited to the first certain number of children.
+   */
+  Query limitToFirst(int limit) =>
+    new Query.fromJsObject(_fb.callMethod('limitToFirst', [limit]));
+
+  /**
+   * Generates a new Query object limited to the last certain number of children.
+   */
+  Query limitToLast(int limit) =>
+    new Query.fromJsObject(_fb.callMethod('limitToLast', [limit]));
+
+  /**
    * Generate a Query object limited to the number of specified children. If
    * combined with startAt, the query will include the specified number of
    * children after the starting point. If combined with endAt, the query will
@@ -554,6 +566,7 @@ class Query {
    * combined with startAt() or endAt(), the query will include the last
    * specified number of children.
    */
+  @deprecated
   Query limit(int limit) =>
       new Query.fromJsObject(_fb.callMethod('limit', [limit]));
 

--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -547,6 +547,30 @@ class Query {
   }
 
   /**
+   * Generates a new Query object ordered by the specified child key.
+   */
+  Query orderByChild(String key) =>
+    new Query.fromJsObject(_fb.callMethod('orderByChild', [key]));
+
+  /**
+   * Generates a new Query object ordered by key.
+   */
+  Query orderByKey() =>
+    new Query.fromJsObject(_fb.callMethod('orderByKey'));
+
+  /**
+   * Generates a new Query object ordered by child values.
+   */
+  Query orderByValue() =>
+    new Query.fromJsObject(_fb.callMethod('orderByValue'));
+
+  /**
+   * Generates a new Query object ordered by priority.
+   */
+  Query orderByPriority() =>
+    new Query.fromJsObject(_fb.callMethod('orderByPriority'));
+
+  /**
    * Generates a new Query object limited to the first certain number of children.
    */
   Query limitToFirst(int limit) =>

--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -391,6 +391,17 @@ class Firebase extends Query {
   }
 
   /**
+   * Updates the email associated with an email / password user account.
+   */
+  Future changeEmail(Map credentials) {
+    var c = new Completer();
+    _fb.callMethod('changeEmail', [jsify(credentials), (err) {
+      _resolveFuture(c, err, null);
+    }]);
+    return c.future;
+  }
+
+  /**
    * Changes the password of an existing user using an email / password combination.
    */
   Future changePassword(Map credentials) {

--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -571,6 +571,14 @@ class Query {
     new Query.fromJsObject(_fb.callMethod('orderByPriority'));
 
   /**
+   * Creates a Query which includes children which match the specified value.
+   */
+  Query equalTo(value, [key]) {
+    var args = key == null ? [value] : [value, key];
+    return new Query.fromJsObject(_fb.callMethod('equalTo', args));
+  }
+
+  /**
    * Generates a new Query object limited to the first certain number of children.
    */
   Query limitToFirst(int limit) =>

--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -547,6 +547,22 @@ class Query {
   }
 
   /**
+   * Listens for exactly one event of the specified event type, and then stops
+   * listening.
+   */
+  Future<DataSnapshot> once(String eventType) {
+    var completer = new Completer<DataSnapshot>();
+
+    _fb.callMethod('once', [eventType, (jsSnapshot) {
+      var snapshot = new DataSnapshot.fromJsObject(jsSnapshot);
+      completer.complete(snapshot);
+    }, (error) {
+      completer.completeError(error);
+    }]);
+    return completer.future;
+  }
+
+  /**
    * Generates a new Query object ordered by the specified child key.
    */
   Query orderByChild(String key) =>
@@ -569,6 +585,38 @@ class Query {
    */
   Query orderByPriority() =>
     new Query.fromJsObject(_fb.callMethod('orderByPriority'));
+
+  /**
+   * Create a Query with the specified starting point. The starting point is
+   * specified using a priority and an optional child name. If no arguments
+   * are provided, the starting point will be the beginning of the data.
+   *
+   * The starting point is inclusive, so children with exactly the specified
+   * priority will be included. Though if the optional name is specified, then
+   * the children that have exactly the specified priority must also have a
+   * name greater than or equal to the specified name.
+   *
+   * startAt() can be combined with endAt() or limit() to create further
+   * restrictive queries.
+   */
+  Query startAt({int priority, String name}) =>
+    new Query.fromJsObject(_fb.callMethod('startAt', _removeTrailingNulls([priority, name])));
+
+  /**
+   * Create a Query with the specified ending point. The ending point is
+   * specified using a priority and an optional child name. If no arguments
+   * are provided, the ending point will be the end of the data.
+   *
+   * The ending point is inclusive, so children with exactly the specified
+   * priority will be included. Though if the optional name is specified, then
+   * children that have exactly the specified priority must also have a name
+   * less than or equal to the specified name.
+   *
+   * endAt() can be combined with startAt() or limit() to create further
+   * restrictive queries.
+   */
+  Query endAt({int priority, String name}) =>
+    new Query.fromJsObject(_fb.callMethod('endAt', _removeTrailingNulls([priority, name])));
 
   /**
    * Creates a Query which includes children which match the specified value.
@@ -603,58 +651,10 @@ class Query {
       new Query.fromJsObject(_fb.callMethod('limit', [limit]));
 
   /**
-   * Create a Query with the specified starting point. The starting point is
-   * specified using a priority and an optional child name. If no arguments
-   * are provided, the starting point will be the beginning of the data.
-   *
-   * The starting point is inclusive, so children with exactly the specified
-   * priority will be included. Though if the optional name is specified, then
-   * the children that have exactly the specified priority must also have a
-   * name greater than or equal to the specified name.
-   *
-   * startAt() can be combined with endAt() or limit() to create further
-   * restrictive queries.
-   */
-  Query startAt({int priority, String name}) =>
-      new Query.fromJsObject(_fb.callMethod('startAt', _removeTrailingNulls([priority, name])));
-
-  /**
-   * Create a Query with the specified ending point. The ending point is
-   * specified using a priority and an optional child name. If no arguments
-   * are provided, the ending point will be the end of the data.
-   *
-   * The ending point is inclusive, so children with exactly the specified
-   * priority will be included. Though if the optional name is specified, then
-   * children that have exactly the specified priority must also have a name
-   * less than or equal to the specified name.
-   *
-   * endAt() can be combined with startAt() or limit() to create further
-   * restrictive queries.
-   */
-  Query endAt({int priority, String name}) =>
-      new Query.fromJsObject(_fb.callMethod('endAt', _removeTrailingNulls([priority, name])));
-
-  /**
    * Queries are attached to a location in your Firebase. This method will
    * return a Firebase reference to that location.
    */
   Firebase ref() => new Firebase.fromJsObject(_fb.callMethod('ref'));
-
-  /**
-   * Listens for exactly one event of the specified event type, and then stops
-   * listening.
-   */
-  Future<DataSnapshot> once(String eventType) {
-    var completer = new Completer<DataSnapshot>();
-
-    _fb.callMethod('once', [eventType, (jsSnapshot) {
-      var snapshot = new DataSnapshot.fromJsObject(jsSnapshot);
-      completer.complete(snapshot);
-    }, (error) {
-      completer.completeError(error);
-    }]);
-    return completer.future;
-  }
 }
 
 List _removeTrailingNulls(List args) {

--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -251,8 +251,8 @@ class Firebase extends Query {
   Future set(value) {
     var c = new Completer();
     value = jsify(value);
-    _fb.callMethod('set', [value, (err, res) {
-      _resolveFuture(c, err, res);
+    _fb.callMethod('set', [value, (err) {
+      _resolveFuture(c, err, null);
     }]);
     return c.future;
   }
@@ -268,8 +268,8 @@ class Firebase extends Query {
   Future update(Map<String, dynamic> value) {
     var c = new Completer();
     var jsValue = jsify(value);
-    _fb.callMethod('update', [jsValue, (err, res) {
-      _resolveFuture(c, err, res);
+    _fb.callMethod('update', [jsValue, (err) {
+      _resolveFuture(c, err, null);
     }]);
     return c.future;
   }
@@ -286,8 +286,8 @@ class Firebase extends Query {
    */
   Future remove() {
     var c = new Completer();
-    _fb.callMethod('remove', [(err, res) {
-      _resolveFuture(c, err, res);
+    _fb.callMethod('remove', [(err) {
+      _resolveFuture(c, err, null);
     }]);
     return c.future;
   }
@@ -317,8 +317,8 @@ class Firebase extends Query {
   Future setWithPriority(value, int priority) {
     var c = new Completer();
     value = jsify(value);
-    _fb.callMethod('setWithPriority', [value, priority, (err, res) {
-      _resolveFuture(c, err, res);
+    _fb.callMethod('setWithPriority', [value, priority, (err) {
+      _resolveFuture(c, err, null);
     }]);
     return c.future;
   }
@@ -338,8 +338,8 @@ class Firebase extends Query {
    */
   Future setPriority(int priority) {
     var c = new Completer();
-    _fb.callMethod('setPriority', [priority, (err, res) {
-      _resolveFuture(c, err, res);
+    _fb.callMethod('setPriority', [priority, (err) {
+      _resolveFuture(c, err, null);
     }]);
     return c.future;
   }
@@ -385,7 +385,7 @@ class Firebase extends Query {
   Future createUser(Map credentials) {
     var c = new Completer();
     _fb.callMethod('createUser', [jsify(credentials), (err, [userData]) {
-      _resolveFuture(c, err, null);
+      _resolveFuture(c, err, userData);
     }]);
     return c.future;
   }
@@ -475,7 +475,7 @@ class Query {
   Stream<Event> _createStream(String type) {
     StreamController<Event> controller;
     void startListen() {
-      _fb.callMethod('on', [type, (snapshot, prevChild) {
+      _fb.callMethod('on', [type, (snapshot, [prevChild]) {
         controller.add(
             new Event(new DataSnapshot.fromJsObject(snapshot), prevChild));
       }]);
@@ -541,7 +541,7 @@ class Query {
 
   /**
    * Create a Query with the specified starting point. The starting point is
-   * specified using a priority and an optinal child name. If no arguments
+   * specified using a priority and an optional child name. If no arguments
    * are provided, the starting point will be the beginning of the data.
    *
    * The starting point is inclusive, so children with exactly the specified

--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -11,7 +11,7 @@ import 'transaction_result.dart';
 import 'util.dart';
 
 /**
- * A firebase represents a particular location in your Firebase and can be used
+ * A Firebase represents a particular location in your Firebase and can be used
  * for reading or writing data to that Firebase location.
  */
 class Firebase extends Query {
@@ -206,7 +206,7 @@ class Firebase extends Query {
    * Get a Firebase reference for a location at the specified relative path.
    *
    * The relative path can either be a simple child name, (e.g. 'fred') or a
-   * deeper slash seperated path (e.g. 'fred/name/first').
+   * deeper slash separated path (e.g. 'fred/name/first').
    */
   Firebase child(String path) =>
       new Firebase.fromJsObject(_fb.callMethod('child', [path]));
@@ -280,7 +280,7 @@ class Firebase extends Query {
    *
    * The effect of this delete will be visible immediately and the
    * corresponding events (onValue, onChildAdded, etc.) will be triggered.
-   * Synchronization of the delete to the Firebsae servers will also be
+   * Synchronization of the delete to the Firebase servers will also be
    * started, and the Future returned by this method will complete after the
    * synchronization has finished.
    */
@@ -294,7 +294,7 @@ class Firebase extends Query {
 
   /**
    * Push generates a new child location using a unique name and returns a
-   * Frebase reference to it. This is useful when the children of a Firebase
+   * Firebase reference to it. This is useful when the children of a Firebase
    * location represent a list of items.
    *
    * FIXME: How to implement optional argument to push(value)?

--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -241,6 +241,13 @@ class Firebase extends Query {
   String get name => _fb.callMethod('name');
 
   /**
+   * Gets the absolute URL corresponding to this Firebase reference's location.
+   */
+  String toString() {
+    return _fb.toString();
+  }
+
+  /**
    * Write data to this Firebase location. This will overwrite any data at
    * this location and all child locations.
    *

--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -227,10 +227,17 @@ class Firebase extends Query {
   Firebase root() => new Firebase.fromJsObject(_fb.callMethod('root'));
 
   /**
+   * Returns the last token in a Firebase location.
+   * [key] on the root of a Firebase is `null`.
+   */
+  String get key => _fb.callMethod('key');
+
+  /**
    * The last token in a Firebase location is considered its name.
    *
    * [name] on the root of a Firebase is `null`.
    */
+  @deprecated
   String get name => _fb.callMethod('name');
 
   /**

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: firebase
-version: 0.3.0
+version: 0.4.0
 authors:
 - Anant Narayanan <anant@kix.in>
 - Seth Ladd <sethladd@gmail.com>

--- a/test/test.dart
+++ b/test/test.dart
@@ -80,8 +80,8 @@ void main() {
 
       test('auth-credentials', () {
         schedule(() {
-          return f.createUser(credentials).then((err) {
-            expect(err, null);
+          return f.createUser(credentials).then((res) {
+            expect(res, isNotNull);
             f.authWithPassword(credentials).then((authResponse) {
               expect(authResponse.auth, isNotNull);
               expect(f.authWithPassword(badCredentials), throwsA((error) {
@@ -96,12 +96,12 @@ void main() {
     });
 
     group('createUser', () {
-      test('createUser returns null on success', () {
+      test('createUser returns user data on success', () {
         schedule(() {
           var credentials = {'email': 'createUserTest@example.com',
               'password': 'pswd'};
           return f.createUser(credentials).then((result) {
-            expect(result, null);
+            expect(result['uid'], isNotNull);
             f.removeUser(credentials);
           });
         });

--- a/test/test.dart
+++ b/test/test.dart
@@ -120,6 +120,47 @@ void main() {
 
     });
 
+    group('changeEmail', () {
+      var password = 'pswd';
+
+      test('changeEmail returns null on success', () {
+        var email = 'changeEmailTest@example.com';
+        var newEmail = 'updatedEmailTest@example.com';
+        var changeCredentials = {
+            'oldEmail': email,
+            'newEmail': newEmail,
+            'password': password,
+        };
+        schedule(() {
+          return f.createUser({'email': email, 'password': password}).then((result) {
+            f.changeEmail(changeCredentials).then((result) {
+              expect(result, null);
+              f.removeUser({'email': newEmail, 'password': password});
+            });
+          });
+        });
+      });
+
+      test('changeEmail throws error', () {
+        var email = 'changePasswordErrorTests@example.com';
+        var badCredentials = {
+            'oldEmail': email,
+            'newEmail': 'invalid_email',
+            'password': password,
+        };
+
+        schedule(() {
+          return f.createUser({'email': email, 'password': password}).then((result) {
+            expect(f.changeEmail(badCredentials), throwsA((error) {
+              expect(error['code'], "INVALID_EMAIL");
+              f.removeUser({'email': email, 'password': password});
+              return true;
+            }));
+          });
+        });
+      });
+    });
+
     group('changePassword', () {
       var oldPassword = 'pswd';
       var newPassword = 'updatedPswd';

--- a/test/test.dart
+++ b/test/test.dart
@@ -563,6 +563,34 @@ void main() {
       });
     });
 
+    test('equalTo', () {
+      schedule(() {
+        f.child('equalTo/football').set(20);
+        f.child('equalTo/basketball').set(10);
+        f.child('equalTo/soccer').set(15);
+        f.child('equalTo/baseball').set(15);
+
+        return f.child('equalTo').orderByValue().equalTo(15).once('value').then((snapshot) {
+          var val = snapshot.val();
+          expect(val, {'soccer': 15, 'baseball': 15});
+        });
+      });
+    });
+
+    test('equalTo with Key', () {
+      schedule(() {
+        f.child('equalTo/football').set(20);
+        f.child('equalTo/basketball').set(10);
+        f.child('equalTo/soccer').set(15);
+        f.child('equalTo/baseball').set(15);
+
+        return f.child('equalTo').orderByValue().equalTo(15, 'soccer').once('value').then((snapshot) {
+          var val = snapshot.val();
+          expect(val, {'soccer': 15});
+        });
+      });
+    });
+
     test('startAt', () {
       var child = f.child('query');
 

--- a/test/test.dart
+++ b/test/test.dart
@@ -515,13 +515,13 @@ void main() {
       });
 
       schedule(() {
-        return child.startAt().limit(5).once('value').then((snapshot) {
+        return child.startAt().limitToFirst(5).once('value').then((snapshot) {
           var val = snapshot.val() as Map;
           expect(val.values, [1, 2, 3, 4, 5]);
 
           var lastKey = val.keys.last;
 
-          return child.startAt(name: lastKey).limit(2).once('value');
+          return child.startAt(name: lastKey).limitToFirst(2).once('value');
         }).then((snapshot) {
           var val = snapshot.val() as Map;
           expect(val.values, [5, 6]);
@@ -540,6 +540,45 @@ void main() {
         }).then((snapshot) {
           var val = snapshot.val() as Map;
           expect(val.values, [10]);
+        });
+      });
+    });
+
+    test('limitToFirst', () {
+      schedule(() {
+        f.child('limitToFirst-test/one').setWithPriority('one', 1);
+        f.child('limitToFirst-test/two').setWithPriority('two', 2);
+        f.child('limitToFirst-test/three').setWithPriority('three', 3);
+
+        return f.child('limitToFirst-test').limitToFirst(2).once('value').then((snapshot) {
+          var val = snapshot.val() as Map;
+          expect(val.values, ['one', 'two']);
+        });
+      });
+    });
+
+    test('limitToLast', () {
+      schedule(() {
+        f.child('limitToLast-test/one').setWithPriority('one', 1);
+        f.child('limitToLast-test/two').setWithPriority('two', 2);
+        f.child('limitToLast-test/three').setWithPriority('three', 3);
+
+        return f.child('limitToLast-test').limitToLast(2).once('value').then((snapshot) {
+          var val = snapshot.val() as Map;
+          expect(val.values, ['two', 'three']);
+        });
+      });
+    });
+
+    test('limit (deprecated)', () {
+      schedule(() {
+        f.child('limit-test/one').setWithPriority('one', 1);
+        f.child('limit-test/two').setWithPriority('two', 2);
+        f.child('limit-test/three').setWithPriority('three', 3);
+
+        return f.child('limit-test').limit(1).once('value').then((snapshot) {
+          var val = snapshot.val() as Map;
+          expect(val.values, ['three']);
         });
       });
     });

--- a/test/test.dart
+++ b/test/test.dart
@@ -494,6 +494,75 @@ void main() {
   });
 
   group('query', () {
+
+    test('orderByChild', () {
+      schedule(() {
+        f.child('order-by-child/one/animal').set('aligator');
+        f.child('order-by-child/two/animal').set('zebra');
+        f.child('order-by-child/three/animal').set('monkey');
+
+        return f.child('order-by-child').orderByChild('animal').once('value').then((snapshot) {
+          var items = [];
+          snapshot.forEach((snapshot) {
+            items.add(snapshot.val());
+          });
+          expect(items, [
+            {'animal': 'aligator'},
+            {'animal': 'monkey'},
+            {'animal': 'zebra'},
+          ]);
+        });
+      });
+    });
+
+    test('orderByKey', () {
+      schedule(() {
+        f.child('order-by-key/zebra').set('three');
+        f.child('order-by-key/elephant').set('one');
+        f.child('order-by-key/monkey').set('two');
+
+        return f.child('order-by-key').orderByKey().once('value').then((snapshot) {
+          var items = [];
+          snapshot.forEach((snapshot) {
+            items.add(snapshot.val());
+          });
+          expect(items, ['one', 'two', 'three']);
+        });
+      });
+    });
+
+    test('orderByValue', () {
+      schedule(() {
+        f.child('order-by-value/football').set(20);
+        f.child('order-by-value/basketball').set(10);
+        f.child('order-by-value/baseball').set(15);
+
+        return f.child('order-by-value').orderByValue().once('value').then((snapshot) {
+          var items = [];
+          snapshot.forEach((snapshot) {
+            items.add(snapshot.val());
+          });
+          expect(items, [10, 15, 20]);
+        });
+      });
+    });
+
+    test('orderByPriority', () {
+      schedule(() {
+        f.child('order-by-priority/football').setWithPriority('twenty', 20);
+        f.child('order-by-priority/basketball').setWithPriority('ten', 10);
+        f.child('order-by-priority/baseball').setWithPriority('fifteen', 15);
+
+        return f.child('order-by-priority').orderByPriority().once('value').then((snapshot) {
+          var items = [];
+          snapshot.forEach((snapshot) {
+            items.add(snapshot.val());
+          });
+          expect(items, ['ten', 'fifteen', 'twenty']);
+        });
+      });
+    });
+
     test('startAt', () {
       var child = f.child('query');
 

--- a/test/test.dart
+++ b/test/test.dart
@@ -309,6 +309,10 @@ void main() {
       expect(f.root().name, isNull);
     });
 
+    test('toString returns the absolute url to ref location', () {
+      expect(f.toString(), TEST_URL + Uri.encodeComponent(_testKey));
+    });
+
     test('set', () {
       var value = {'number value': 42};
       return f.set(value).then((v) {

--- a/test/test.html
+++ b/test/test.html
@@ -10,7 +10,7 @@
   </head>
 
   <body>
-    <script src="https://cdn.firebase.com/js/client/1.1.2/firebase.js"></script>
+    <script src="https://cdn.firebase.com/js/client/2.2.2/firebase.js"></script>
     <script type="application/dart" src="test.dart"></script>
     <script src="packages/browser/dart.js"></script>
   </body>


### PR DESCRIPTION

Updated to work with firebase api v. 2.2.2  

Several apis had changed to only send one parameter to a method's callback which will be either an Error, or null. Previously the JS apis returned the error as the first argument, and the result or null as the second.

createUser() will now return user data on success, not simply null.

'name' getter on Firebase is deprecated in favor of 'key'

Data Snapshot now has 'exists' getter (new in api version 2.0.4)

Added the changeEmail() method which became available with api version 2.1.0

Query object now has limitToFirst(), limitToLast(), equalTo(), orderByChild(), orderByKey(), orderByValue() and orderByPriority()