### PR TITLE
added authWithOAuthToken() method.

### DIFF
--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -153,6 +153,21 @@ class Firebase extends Query {
   }
 
   /**
+   * Authenticates a Firebase client using OAuth access tokens or credentials.
+   */
+  Future<AuthResponse> authWithOAuthToken(provider, credentials, {remember: 'default', scope: ''}) {
+    var c = new Completer();
+    _fb.callMethod('authWithOAuthToken', [provider, jsify(credentials), (err, [result]) {
+      if (err != null) {
+        c.completeError(err);
+      } else {
+        c.complete(new AuthResponse(result));
+      }
+    }, jsify({'remember': remember, 'scope': scope})]);
+    return c.future;
+  }
+
+  /**
    * Synchronously retrieves the current authentication state of the client.
    */
   AuthResponse getAuth() {


### PR DESCRIPTION
This should be the very last method missing from the dart port. I skipped it initially because I wasn't sure how to verify it worked.  I took the time to figure it out today and that's when I realized how much data we aren't returning in the AuthResponse (issue #41)