### PR TITLE
updated startAt() and endAt() to fix issue #45

### DIFF
--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -609,8 +609,8 @@ class Query {
     new Query.fromJsObject(_fb.callMethod('orderByPriority'));
 
   /**
-   * Create a Query with the specified starting point. The starting point is
-   * specified using a priority and an optional child name. If no arguments
+   * Creates a Query with the specified starting point. The generated Query
+   * includes children which match the specified starting point. If no arguments
    * are provided, the starting point will be the beginning of the data.
    *
    * The starting point is inclusive, so children with exactly the specified
@@ -618,15 +618,15 @@ class Query {
    * the children that have exactly the specified priority must also have a
    * name greater than or equal to the specified name.
    *
-   * startAt() can be combined with endAt() or limit() to create further
-   * restrictive queries.
+   * startAt() can be combined with endAt() or limitToFirst() or limitToLast()
+   * to create further restrictive queries.
    */
-  Query startAt({int priority, String name}) =>
-    new Query.fromJsObject(_fb.callMethod('startAt', _removeTrailingNulls([priority, name])));
+  Query startAt({dynamic value, String key}) =>
+    new Query.fromJsObject(_fb.callMethod('startAt', _removeTrailingNulls([value, key])));
 
   /**
-   * Create a Query with the specified ending point. The ending point is
-   * specified using a priority and an optional child name. If no arguments
+   * Creates a Query with the specified ending point. The generated Query
+   * includes children which match the specified ending point. If no arguments
    * are provided, the ending point will be the end of the data.
    *
    * The ending point is inclusive, so children with exactly the specified
@@ -634,11 +634,11 @@ class Query {
    * children that have exactly the specified priority must also have a name
    * less than or equal to the specified name.
    *
-   * endAt() can be combined with startAt() or limit() to create further
-   * restrictive queries.
+   * endAt() can be combined with startAt() or limitToFirst() or limitToLast()
+   * to create further restrictive queries.
    */
-  Query endAt({int priority, String name}) =>
-    new Query.fromJsObject(_fb.callMethod('endAt', _removeTrailingNulls([priority, name])));
+  Query endAt({dynamic value, String key}) =>
+    new Query.fromJsObject(_fb.callMethod('endAt', _removeTrailingNulls([value, key])));
 
   /**
    * Creates a Query which includes children which match the specified value.


### PR DESCRIPTION
attempting to address issue #45 

Added several tests to ensure queries are behaving as expected. The parameters could either be named similar to how they were before or they could simply be positional like the javascript api. For now I kept named parameters because that is what the library authors originally went with. I did adjust the names to match the api: value & key