### PR TITLE
Define Firebase.ServerValue.TIMESTAMP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.4
+
+* Added `Firebase.ServerValue.TIMESTAMP` constant
+
 ## 0.6.3
 
 * Added `onComplete` argument to `Firebase.push`.

--- a/lib/src/firebase.dart
+++ b/lib/src/firebase.dart
@@ -489,6 +489,12 @@ class Firebase extends Query {
       c.complete(res);
     }
   }
+
+  static final ServerValue = new _ServerValue();
+}
+
+class _ServerValue {
+  final TIMESTAMP = context['Firebase']['ServerValue']['TIMESTAMP'];
 }
 
 /**

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: firebase
-version: 0.6.3
+version: 0.6.4
 authors:
 - Anant Narayanan <anant@kix.in>
 - Seth Ladd <sethladd@gmail.com>

--- a/test/firebase_test.dart
+++ b/test/firebase_test.dart
@@ -1044,6 +1044,12 @@ void main() {
         'https://github.com/firebase/firebase-dart/issues/52');
   });
 
+  group('ServerValue', () {
+    test('TIMESTAMP', () {
+      expect(Firebase.ServerValue.TIMESTAMP['.sv'], 'timestamp');
+    });
+  });
+
   group('onDisconnect', () {
     test('set', () {
       var value = {'onDisconnect set': 1};


### PR DESCRIPTION
I had to write a kind of awkward _ServerValue class to get the syntax to the be the same as the js side.

The test may be overly specific. It tests the value of `TIMESTAMP` and not just that it exists.