### PR TITLE
Dependencies mention in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,12 @@ in this document.
 
 ### Installation
 
-Install the library from the pub or Github.
+Install the library from the pub or Github:
+
+```
+dependencies:
+  firebase: '^3.0.0'
+```
 
 ### Include Firebase source
 


### PR DESCRIPTION
I think we should explicitly mention the pubspec dependency in readme. Because of the latest (not backward compatible) update.