### PR TITLE
Transactions sample

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -12,6 +12,7 @@
   <ul>
     <li><a href="auth/index.html">auth</a></li>
     <li><a href="realtime_database/index.html">database</a></li>
+    <li><a href="realtime_database_transactions/index.html">database with transactions</a></li>
     <li><a href="storage/index.html">storage</a></li>
   </ul>
 </div>

--- a/example/realtime_database_transactions/index.dart
+++ b/example/realtime_database_transactions/index.dart
@@ -1,0 +1,124 @@
+import 'dart:html';
+
+import 'package:firebase/firebase.dart' as fb;
+import 'package:firebase/src/assets/assets.dart';
+
+main() async {
+  // Use for firebase package development only
+  await config();
+
+  fb.initializeApp(
+      apiKey: apiKey,
+      authDomain: authDomain,
+      databaseURL: databaseUrl,
+      storageBucket: storageBucket);
+
+  new MessagesApp().showMessages();
+}
+
+// This version of MessagesApp uses transaction() method
+// for all updates on the data.
+class MessagesApp {
+  final fb.DatabaseReference ref;
+  final UListElement messages;
+  final InputElement newMessage;
+  final InputElement submit;
+  final FormElement newMessageForm;
+
+  MessagesApp()
+      : ref = fb.database().ref("pkg_firebase/examples/database_transaction"),
+        messages = querySelector("#messages"),
+        newMessage = querySelector("#new_message"),
+        submit = querySelector('#submit'),
+        newMessageForm = querySelector("#new_message_form") {
+    newMessage.disabled = false;
+
+    submit.disabled = false;
+
+    this.newMessageForm.onSubmit.listen((e) async {
+      e.preventDefault();
+
+      if (newMessage.value.trim().isNotEmpty) {
+        var map = {"text": newMessage.value};
+
+        try {
+          var childRef = ref.push();
+          // Push of data via transaction
+          await childRef.transaction((_) => map);
+          newMessage.value = "";
+        } catch (e) {
+          print("Error while writing to db, $e");
+        }
+      }
+    });
+  }
+
+  void showMessages() {
+    this.ref.onChildAdded.listen((e) {
+      fb.DataSnapshot datasnapshot = e.snapshot;
+
+      var spanElement = new SpanElement()..text = datasnapshot.val()["text"];
+
+      var aElementDelete = new AnchorElement(href: "#")
+        ..text = "Delete"
+        ..onClick.listen((e) {
+          e.preventDefault();
+          _deleteItem(datasnapshot);
+        });
+
+      var aElementUpdate = new AnchorElement(href: "#")
+        ..text = "To Uppercase"
+        ..onClick.listen((e) {
+          e.preventDefault();
+          _uppercaseItem(datasnapshot);
+        });
+
+      var element = new LIElement()
+        ..id = datasnapshot.key
+        ..append(spanElement)
+        ..append(aElementDelete)
+        ..append(aElementUpdate);
+      messages.append(element);
+    });
+
+    this.ref.onChildChanged.listen((e) {
+      fb.DataSnapshot datasnapshot = e.snapshot;
+      var element = querySelector("#${datasnapshot.key} span");
+
+      if (element != null) {
+        element.text = datasnapshot.val()["text"];
+      }
+    });
+
+    this.ref.onChildRemoved.listen((e) {
+      fb.DataSnapshot datasnapshot = e.snapshot;
+
+      var element = querySelector("#${datasnapshot.key}");
+
+      if (element != null) {
+        element.remove();
+      }
+    });
+  }
+
+  _deleteItem(fb.DataSnapshot datasnapshot) async {
+    try {
+      // transaction((_) => null) doesn't work when compiled to JS
+      // probably because of https://github.com/dart-lang/sdk/issues/24088
+      await this.ref.child(datasnapshot.key).transaction((_) => {});
+    } catch (e) {
+      print("Error while deleting item, $e");
+    }
+  }
+
+  _uppercaseItem(fb.DataSnapshot datasnapshot) async {
+    try {
+      // update data in transaction - e.g. take prev value,
+      // update it and return it.
+      await this.ref.child(datasnapshot.key).transaction(
+          (prevValue) => {"text": prevValue["text"].toUpperCase()});
+    } catch (e) {
+      print("Error while updating item, $e");
+    }
+  }
+}

--- a/example/realtime_database_transactions/index.dart
+++ b/example/realtime_database_transactions/index.dart
@@ -17,7 +17,7 @@ main() async {
 }
 
 // This version of MessagesApp uses transaction() method
-// for all updates on the data.
+// for all updates on the data
 class MessagesApp {
   final fb.DatabaseReference ref;
   final UListElement messages;
@@ -113,8 +113,8 @@ class MessagesApp {
 
   _uppercaseItem(fb.DataSnapshot datasnapshot) async {
     try {
-      // update data in transaction - e.g. take prev value,
-      // update it and return it.
+      // Update data in transaction - e.g. take previous value,
+      // update it and return it
       await this.ref.child(datasnapshot.key).transaction(
           (prevValue) => {"text": prevValue["text"].toUpperCase()});
     } catch (e) {

--- a/example/realtime_database_transactions/index.html
+++ b/example/realtime_database_transactions/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Realtime database with transactions demo</title>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+        integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  <style type="text/css">
+    ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+
+    li {
+      margin: 0;
+      padding: 4px 2px;
+      border-bottom: 1px solid silver;
+      overflow: auto;
+    }
+
+    #messages_wrapper {
+      width: 500px;
+      margin-bottom: 15px;
+      overflow-y: auto;
+    }
+
+    #messages a {
+      float: right;
+      margin-left: 10px;
+    }
+
+    #new_message {
+      width: 350px;
+    }
+  </style>
+</head>
+<body>
+<div class="container">
+  <h1>Messages with transactions demo</h1>
+  <div id="messages_wrapper">
+    <ul id="messages"></ul>
+  </div>
+  <form id="new_message_form">
+    <input type="text" placeholder="Your Message" id="new_message" disabled>
+    <input type="submit" value="Send" id="submit" disabled>
+  </form>
+</div>
+<script src="https://www.gstatic.com/firebasejs/3.6.5/firebase.js"></script>
+<script src="index.dart" type="application/dart"></script>
+<script src="packages/browser/dart.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Because of this issue: https://github.com/firebase/firebase-dart/issues/52

I created another version of the database example which uses only **transactions** for adding/removing/updating data.

I was able to rewrite it and have it working (also with delete through the transaction).

**BUT!**
I started to play with it and I have found a big differences in final behaviour of Dart and js version when the transaction function returns the same thing.

When I try to do this the transaction method:
* `return undefined;`
  * js - Aborts transaction [according to the docs](https://firebase.google.com/docs/reference/js/firebase.database.Reference#transaction)
  * Dart - not possible to return simply `undefined` (without any interop?). So the only way is to return the old data… I can't use `return null;` for this
* `return null;` 
  * js - deletes the node
  * Dart - deletes the node but only in Dartium (**stops working while compiled to js**)
* `return;`
  * js - same as `return undefined;` 
  * Dart - deletes the node (**stops working when compiled to js**); e.g. same as `return null;`
* `return {};`
  * js - deletes the node
  * Dart - deletes the node (**WORKS compiled to js**)

So the problem is that I am not able to simply do "abortion of the transaction" in Dart (only return the old data) and that `return null` doesn't work for node deletion after compilation. But I found the workaround of `return {};` (it's commented in the sample)

I know that there is [this issue](https://github.com/dart-lang/sdk/issues/24088) but what about devs using the library. Mention this in the documentation of transaction() function? What do you think?