### PR TITLE
Eliminate one-off caches in favor of expando

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -15,6 +15,8 @@ export 'interop/firebase_interop.dart' show FirebaseError, FirebaseOptions;
 ///
 /// See: <https://firebase.google.com/docs/reference/js/firebase.app>.
 class App extends JsObjectWrapper<AppJsImpl> {
+  static final _expando = new Expando<App>();
+
   /// Name of the app.
   String get name => jsObject.name;
 
@@ -22,13 +24,20 @@ class App extends JsObjectWrapper<AppJsImpl> {
   FirebaseOptions get options => jsObject.options;
 
   /// Creates a new App from a [jsObject].
-  App.fromJsObject(AppJsImpl jsObject) : super.fromJsObject(jsObject);
+  static App get(AppJsImpl jsObject) {
+    if (jsObject == null) {
+      return null;
+    }
+    return _expando[jsObject] ??= new App._fromJsObject(jsObject);
+  }
+
+  App._fromJsObject(AppJsImpl jsObject) : super.fromJsObject(jsObject);
 
   /// Returns [Auth] service.
-  Auth auth() => new Auth.fromJsObject(jsObject.auth());
+  Auth auth() => Auth.get(jsObject.auth());
 
   /// Returns [Database] service.
-  Database database() => new Database.fromJsObject(jsObject.database());
+  Database database() => Database.get(jsObject.database());
 
   /// Deletes the app and frees resources of all App's services.
   Future delete() => handleThenable(jsObject.delete());
@@ -37,6 +46,6 @@ class App extends JsObjectWrapper<AppJsImpl> {
   Storage storage([String url]) {
     var jsObjectStorage =
         (url != null) ? jsObject.storage(url) : jsObject.storage();
-    return new Storage.fromJsObject(jsObjectStorage);
+    return Storage.get(jsObjectStorage);
   }
 }

--- a/lib/src/auth.dart
+++ b/lib/src/auth.dart
@@ -41,6 +41,8 @@ class UserInfo<T extends firebase_interop.UserInfoJsImpl>
 ///
 /// See: <https://firebase.google.com/docs/reference/js/firebase.User>.
 class User extends UserInfo<firebase_interop.UserJsImpl> {
+  static final _expando = new Expando<User>();
+
   /// If the user's email address has been already verified.
   bool get emailVerified => jsObject.emailVerified;
 
@@ -57,7 +59,19 @@ class User extends UserInfo<firebase_interop.UserJsImpl> {
   String get refreshToken => jsObject.refreshToken;
 
   /// Creates a new User from a [jsObject].
-  User.fromJsObject(firebase_interop.UserJsImpl jsObject)
+  ///
+  /// If an instance of [User] is already associated with [jsObject], it is
+  /// returned instead of creating a new instance.
+  ///
+  /// If [jsObject] is `null`, `null` is returned.
+  static User get(firebase_interop.UserJsImpl jsObject) {
+    if (jsObject == null) {
+      return null;
+    }
+    return _expando[jsObject] ??= new User._fromJsObject(jsObject);
+  }
+
+  User._fromJsObject(firebase_interop.UserJsImpl jsObject)
       : super.fromJsObject(jsObject);
 
   /// Deletes and signs out the user.
@@ -90,8 +104,8 @@ class User extends UserInfo<firebase_interop.UserJsImpl> {
 
   /// Links the user account with the given [credential] and returns the user.
   Future<User> linkWithCredential(AuthCredential credential) =>
-      handleThenableWithMapper(jsObject.linkWithCredential(credential),
-          (u) => new User.fromJsObject(u));
+      handleThenableWithMapper(
+          jsObject.linkWithCredential(credential), User.get);
 
   /// Links the authenticated [provider] to the user account using
   /// a pop-up based OAuth flow.
@@ -142,9 +156,8 @@ class User extends UserInfo<firebase_interop.UserJsImpl> {
       handleThenable(jsObject.sendEmailVerification());
 
   /// Unlinks a provider with [providerId] from a user account.
-  Future<User> unlink(String providerId) => handleThenableWithMapper(
-      jsObject.unlink(providerId),
-      (firebase_interop.UserJsImpl u) => new User.fromJsObject(u));
+  Future<User> unlink(String providerId) =>
+      handleThenableWithMapper(jsObject.unlink(providerId), User.get);
 
   /// Updates the user's e-mail address to [newEmail].
   Future updateEmail(String newEmail) =>
@@ -174,33 +187,13 @@ class User extends UserInfo<firebase_interop.UserJsImpl> {
 ///
 /// See: <https://firebase.google.com/docs/reference/js/firebase.auth.Auth>.
 class Auth extends JsObjectWrapper<AuthJsImpl> {
-  App _app;
+  static final _expando = new Expando<Auth>();
 
   /// App for this instance of auth service.
-  App get app {
-    if (_app != null) {
-      _app.jsObject = jsObject.app;
-    } else {
-      _app = new App.fromJsObject(jsObject.app);
-    }
-    return _app;
-  }
+  App get app => App.get(jsObject.app);
 
-  User _currentUser;
-
-  /// Currently signed-in user.
-  User get currentUser {
-    if (jsObject.currentUser != null) {
-      if (_currentUser != null) {
-        _currentUser.jsObject = jsObject.currentUser;
-      } else {
-        _currentUser = new User.fromJsObject(jsObject.currentUser);
-      }
-    } else {
-      _currentUser = null;
-    }
-    return _currentUser;
-  }
+  /// Currently signed-in [User].
+  User get currentUser => User.get(jsObject.currentUser);
 
   Func0 _onAuthUnsubscribe;
   StreamController<User> _changeController;
@@ -211,8 +204,7 @@ class Auth extends JsObjectWrapper<AuthJsImpl> {
   Stream<User> get onAuthStateChanged {
     if (_changeController == null) {
       var nextWrapper = allowInterop((firebase_interop.UserJsImpl user) {
-        _changeController
-            .add(user != null ? new User.fromJsObject(user) : null);
+        _changeController.add(User.get(user));
       });
 
       var errorWrapper = allowInterop((e) => _changeController.addError(e));
@@ -242,8 +234,7 @@ class Auth extends JsObjectWrapper<AuthJsImpl> {
   Stream<User> get onIdTokenChanged {
     if (_idTokenChangedController == null) {
       var nextWrapper = allowInterop((firebase_interop.UserJsImpl user) {
-        _idTokenChangedController
-            .add(user != null ? new User.fromJsObject(user) : null);
+        _idTokenChangedController.add(User.get(user));
       });
 
       var errorWrapper =
@@ -267,7 +258,14 @@ class Auth extends JsObjectWrapper<AuthJsImpl> {
   }
 
   /// Creates a new Auth from a [jsObject].
-  Auth.fromJsObject(AuthJsImpl jsObject) : super.fromJsObject(jsObject);
+  static Auth get(AuthJsImpl jsObject) {
+    if (jsObject == null) {
+      return null;
+    }
+    return _expando[jsObject] ??= new Auth._fromJsObject(jsObject);
+  }
+
+  Auth._fromJsObject(AuthJsImpl jsObject) : super.fromJsObject(jsObject);
 
   /// Applies a verification [code] sent to the user by e-mail or by other
   /// out-of-band mechanism.
@@ -292,8 +290,7 @@ class Auth extends JsObjectWrapper<AuthJsImpl> {
   /// or the password is not valid.
   Future<User> createUserWithEmailAndPassword(String email, String password) =>
       handleThenableWithMapper(
-          jsObject.createUserWithEmailAndPassword(email, password),
-          (u) => new User.fromJsObject(u));
+          jsObject.createUserWithEmailAndPassword(email, password), User.get);
 
   /// Returns the list of provider IDs for the given [email] address,
   /// that can be used to sign in.
@@ -324,27 +321,26 @@ class Auth extends JsObjectWrapper<AuthJsImpl> {
   /// Signs in as an anonymous user. If an anonymous user is already
   /// signed in, that user will be returned. In other case, new anonymous
   /// [User] identity is created and returned.
-  Future<User> signInAnonymously() => handleThenableWithMapper(
-      jsObject.signInAnonymously(), (u) => new User.fromJsObject(u));
+  Future<User> signInAnonymously() =>
+      handleThenableWithMapper(jsObject.signInAnonymously(), User.get);
 
   /// Signs in with the given [credential] and returns the [User].
   Future<User> signInWithCredential(AuthCredential credential) =>
-      handleThenableWithMapper(jsObject.signInWithCredential(credential),
-          (u) => new User.fromJsObject(u));
+      handleThenableWithMapper(
+          jsObject.signInWithCredential(credential), User.get);
 
   /// Signs in with the custom [token] and returns the [User].
   /// Custom token must be generated by an auth backend.
   /// Fails with an error if the token is invalid, expired or not accepted
   /// by Firebase Auth service.
-  Future<User> signInWithCustomToken(String token) => handleThenableWithMapper(
-      jsObject.signInWithCustomToken(token), (u) => new User.fromJsObject(u));
+  Future<User> signInWithCustomToken(String token) =>
+      handleThenableWithMapper(jsObject.signInWithCustomToken(token), User.get);
 
   /// Signs in with [email] and [password] and returns the [User].
   /// Fails with an error if the sign in is not successful.
   Future<User> signInWithEmailAndPassword(String email, String password) =>
       handleThenableWithMapper(
-          jsObject.signInWithEmailAndPassword(email, password),
-          (u) => new User.fromJsObject(u));
+          jsObject.signInWithEmailAndPassword(email, password), User.get);
 
   /// Signs in using a popup-based OAuth authentication flow with the
   /// given [provider].
@@ -562,21 +558,8 @@ class PhoneAuthProvider extends AuthProvider<PhoneAuthProviderJsImpl> {
 /// operationType could be 'signIn' for a sign-in operation, 'link' for a
 /// linking operation and 'reauthenticate' for a reauthentication operation.
 class UserCredential extends JsObjectWrapper<UserCredentialJsImpl> {
-  User _user;
-
   /// Returns the user.
-  User get user {
-    if (jsObject.user != null) {
-      if (_user != null) {
-        _user.jsObject = jsObject.user;
-      } else {
-        _user = new User.fromJsObject(jsObject.user);
-      }
-    } else {
-      _user = null;
-    }
-    return _user;
-  }
+  User get user => User.get(jsObject.user);
 
   /// Returns the auth credential.
   AuthCredential get credential => jsObject.credential;

--- a/lib/src/interop/database_interop.dart
+++ b/lib/src/interop/database_interop.dart
@@ -112,9 +112,7 @@ abstract class ThenableReferenceJsImpl extends ReferenceJsImpl
 @anonymous
 class TransactionJsImpl {
   external bool get committed;
-  external void set committed(bool c);
   external DataSnapshotJsImpl get snapshot;
-  external void set snapshot(DataSnapshotJsImpl s);
 
   external factory TransactionJsImpl(
       {bool committed, DataSnapshotJsImpl snapshot});

--- a/lib/src/interop/storage_interop.dart
+++ b/lib/src/interop/storage_interop.dart
@@ -89,7 +89,8 @@ class UploadMetadataJsImpl extends SettableMetadataJsImpl {
 }
 
 @JS('UploadTask')
-abstract class UploadTaskJsImpl implements ThenableJsImpl {
+abstract class UploadTaskJsImpl
+    implements ThenableJsImpl<UploadTaskSnapshotJsImpl> {
   external UploadTaskSnapshotJsImpl get snapshot;
   external void set snapshot(UploadTaskSnapshotJsImpl t);
   external bool cancel();

--- a/lib/src/js.dart
+++ b/lib/src/js.dart
@@ -2,7 +2,7 @@
 /// wrappers extend from it.
 abstract class JsObjectWrapper<T> {
   /// JS object.
-  T jsObject;
+  final T jsObject;
 
   /// Creates a new JsObjectWrapper type from a [jsObject].
   JsObjectWrapper.fromJsObject(this.jsObject);

--- a/lib/src/storage.dart
+++ b/lib/src/storage.dart
@@ -19,17 +19,10 @@ enum TaskState { RUNNING, PAUSED, SUCCESS, CANCELED, ERROR }
 ///
 /// See: <https://firebase.google.com/docs/reference/js/firebase.storage.Storage>
 class Storage extends JsObjectWrapper<storage_interop.StorageJsImpl> {
-  App _app;
+  static final _expando = new Expando<Storage>();
 
   /// App for this instance of storage service.
-  App get app {
-    if (_app != null) {
-      _app.jsObject = jsObject.app;
-    } else {
-      _app = new App.fromJsObject(jsObject.app);
-    }
-    return _app;
-  }
+  App get app => App.get(jsObject.app);
 
   /// Returns the maximum time to retry operations other than uploads
   /// or downloads (in milliseconds).
@@ -39,16 +32,23 @@ class Storage extends JsObjectWrapper<storage_interop.StorageJsImpl> {
   int get maxUploadRetryTime => jsObject.maxUploadRetryTime;
 
   /// Creates a new Storage from a [jsObject].
-  Storage.fromJsObject(storage_interop.StorageJsImpl jsObject)
+  static Storage get(storage_interop.StorageJsImpl jsObject) {
+    if (jsObject == null) {
+      return null;
+    }
+    return _expando[jsObject] ??= new Storage._fromJsObject(jsObject);
+  }
+
+  Storage._fromJsObject(storage_interop.StorageJsImpl jsObject)
       : super.fromJsObject(jsObject);
 
   /// Returns a [StorageReference] for the given [path] in the default bucket.
   StorageReference ref([String path]) =>
-      new StorageReference.fromJsObject(jsObject.ref(path));
+      StorageReference.get(jsObject.ref(path));
 
   /// Returns a [StorageReference] for the given absolute [url].
   StorageReference refFromURL(String url) =>
-      new StorageReference.fromJsObject(jsObject.refFromURL(url));
+      StorageReference.get(jsObject.refFromURL(url));
 
   /// Sets the maximum operation retry time to a value of [time].
   void setMaxOperationRetryTime(int time) =>
@@ -65,6 +65,8 @@ class Storage extends JsObjectWrapper<storage_interop.StorageJsImpl> {
 /// See: <https://firebase.google.com/docs/reference/js/firebase.storage.Reference>
 class StorageReference
     extends JsObjectWrapper<storage_interop.ReferenceJsImpl> {
+  static final _expando = new Expando<StorageReference>();
+
   /// The name of the bucket.
   String get bucket => jsObject.bucket;
 
@@ -74,55 +76,31 @@ class StorageReference
   /// The short name. Which is the last component of the full path.
   String get name => jsObject.name;
 
-  StorageReference _parent;
-
   /// The reference to the parent location of this reference.
   /// It is [null] in case of root StorageReference.
-  StorageReference get parent {
-    if (jsObject.parent != null) {
-      if (_parent != null) {
-        _parent.jsObject = jsObject.parent;
-      } else {
-        _parent = new StorageReference.fromJsObject(jsObject.parent);
-      }
-    } else {
-      _parent = null;
-    }
-    return _parent;
-  }
-
-  StorageReference _root;
+  StorageReference get parent => StorageReference.get(jsObject.parent);
 
   /// The reference to the root of this storage reference's bucket.
-  StorageReference get root {
-    if (_root != null) {
-      _root.jsObject = jsObject.root;
-    } else {
-      _root = new StorageReference.fromJsObject(jsObject.root);
-    }
-    return _root;
-  }
-
-  Storage _storage;
+  StorageReference get root => StorageReference.get(jsObject.root);
 
   /// The [Storage] service associated with this reference.
-  Storage get storage {
-    if (_storage != null) {
-      _storage.jsObject = jsObject.storage;
-    } else {
-      _storage = new Storage.fromJsObject(jsObject.storage);
-    }
-    return _storage;
-  }
+  Storage get storage => Storage.get(jsObject.storage);
 
   /// Creates a new StorageReference from a [jsObject].
-  StorageReference.fromJsObject(storage_interop.ReferenceJsImpl jsObject)
+  static StorageReference get(storage_interop.ReferenceJsImpl jsObject) {
+    if (jsObject == null) {
+      return null;
+    }
+    return _expando[jsObject] ??= new StorageReference._fromJsObject(jsObject);
+  }
+
+  StorageReference._fromJsObject(storage_interop.ReferenceJsImpl jsObject)
       : super.fromJsObject(jsObject);
 
   /// Returns a child StorageReference to a relative [path]
   /// from the actual reference.
   StorageReference child(String path) =>
-      new StorageReference.fromJsObject(jsObject.child(path));
+      StorageReference.get(jsObject.child(path));
 
   /// Deletes the object at the actual location.
   Future delete() => handleThenable(jsObject.delete());
@@ -134,8 +112,8 @@ class StorageReference
   }
 
   /// Returns a [FullMetadata] from this reference at actual location.
-  Future<FullMetadata> getMetadata() => handleThenableWithMapper(
-      jsObject.getMetadata(), (m) => new FullMetadata.fromJsObject(m));
+  Future<FullMetadata> getMetadata() =>
+      handleThenableWithMapper(jsObject.getMetadata(), FullMetadata.get);
 
   /// Uploads data [blob] to the actual location with optional [metadata].
   /// Returns the [UploadTask] which can be used to monitor and manage
@@ -147,7 +125,7 @@ class StorageReference
     } else {
       taskImpl = jsObject.put(blob);
     }
-    return new UploadTask.fromJsObject(taskImpl);
+    return UploadTask.get(taskImpl);
   }
 
   /// Uploads String [data] to the actual location with optional String [format]
@@ -163,7 +141,7 @@ class StorageReference
     } else {
       taskImpl = jsObject.putString(data);
     }
-    return new UploadTask.fromJsObject(taskImpl);
+    return UploadTask.get(taskImpl);
   }
 
   /// Returns the String representation of the current storage reference.
@@ -173,8 +151,8 @@ class StorageReference
   /// Updates metadata from this reference at actual location with
   /// the new [metadata].
   Future<FullMetadata> updateMetadata(SettableMetadata metadata) =>
-      handleThenableWithMapper(jsObject.updateMetadata(metadata.jsObject),
-          (m) => new FullMetadata.fromJsObject(m));
+      handleThenableWithMapper(
+          jsObject.updateMetadata(metadata.jsObject), FullMetadata.get);
 }
 
 /// The full set of object metadata, including read-only properties.
@@ -182,6 +160,8 @@ class StorageReference
 /// See: <https://firebase.google.com/docs/reference/js/firebase.storage.FullMetadata>
 class FullMetadata
     extends _UploadMetadataBase<storage_interop.FullMetadataJsImpl> {
+  static final _expando = new Expando<FullMetadata>();
+
   /// The bucket the actual object is contained in.
   String get bucket => jsObject.bucket;
 
@@ -209,36 +189,15 @@ class FullMetadata
   /// Returns the time it was last updated as a [DateTime].
   DateTime get updated => DateTime.parse(jsObject.updated);
 
-  /// Creates a new FullMetadata with optional metadata parameters.
-  factory FullMetadata(
-          {String bucket,
-          List<String> downloadURLs,
-          String fullPath,
-          String generation,
-          String metageneration,
-          String name,
-          int size,
-          String timeCreated,
-          String updated,
-          String md5Hash,
-          String cacheControl,
-          String contentDisposition,
-          String contentEncoding,
-          String contentLanguage,
-          String contentType,
-          Map customMetadata}) =>
-      new FullMetadata.fromJsObject(new storage_interop.FullMetadataJsImpl(
-          md5Hash: md5Hash,
-          cacheControl: cacheControl,
-          contentDisposition: contentDisposition,
-          contentEncoding: contentEncoding,
-          contentLanguage: contentLanguage,
-          contentType: contentType,
-          customMetadata:
-              (customMetadata != null) ? jsify(customMetadata) : null));
-
   /// Creates a new FullMetadata from a [jsObject].
-  FullMetadata.fromJsObject(jsObject) : super.fromJsObject(jsObject);
+  static FullMetadata get(jsObject) {
+    if (jsObject == null) {
+      return null;
+    }
+    return _expando[jsObject] ??= new FullMetadata._fromJsObject(jsObject);
+  }
+
+  FullMetadata._fromJsObject(jsObject) : super.fromJsObject(jsObject);
 }
 
 /// Object metadata that can be set at upload.
@@ -270,6 +229,8 @@ class UploadMetadata
       : super.fromJsObject(jsObject);
 }
 
+// TODO(kevmoo) - figure out if a settable md5Hash makes any sense
+// See https://stackoverflow.com/q/44959703/39827
 abstract class _UploadMetadataBase<
         T extends storage_interop.UploadMetadataJsImpl>
     extends _SettableMetadataBase<T> {
@@ -287,31 +248,30 @@ abstract class _UploadMetadataBase<
 ///
 /// See: <https://firebase.google.com/docs/reference/js/firebase.storage.UploadTask>.
 class UploadTask extends JsObjectWrapper<storage_interop.UploadTaskJsImpl> {
+  static final _expando = new Expando<UploadTask>();
+
   Future<UploadTaskSnapshot> _future;
 
   /// Returns the UploadTaskSnapshot when the upload successfully completes.
   Future<UploadTaskSnapshot> get future {
     if (_future == null) {
-      _future = handleThenableWithMapper(
-          jsObject, (val) => new UploadTaskSnapshot.fromJsObject(val));
+      _future = handleThenableWithMapper(jsObject, UploadTaskSnapshot.get);
     }
     return _future;
   }
 
-  UploadTaskSnapshot _snapshot;
-
   /// Returns the upload task snapshot of the current task state.
-  UploadTaskSnapshot get snapshot {
-    if (_snapshot != null) {
-      _snapshot.jsObject = jsObject.snapshot;
-    } else {
-      _snapshot = new UploadTaskSnapshot.fromJsObject(jsObject.snapshot);
-    }
-    return _snapshot;
-  }
+  UploadTaskSnapshot get snapshot => UploadTaskSnapshot.get(jsObject.snapshot);
 
   /// Creates a new UploadTask from a [jsObject].
-  UploadTask.fromJsObject(storage_interop.UploadTaskJsImpl jsObject)
+  static UploadTask get(storage_interop.UploadTaskJsImpl jsObject) {
+    if (jsObject == null) {
+      return null;
+    }
+    return _expando[jsObject] ??= new UploadTask._fromJsObject(jsObject);
+  }
+
+  UploadTask._fromJsObject(storage_interop.UploadTaskJsImpl jsObject)
       : super.fromJsObject(jsObject);
 
   /// Cancels a running task. Has no effect on a complete or failed task.
@@ -326,7 +286,7 @@ class UploadTask extends JsObjectWrapper<storage_interop.UploadTaskJsImpl> {
     if (_changeController == null) {
       var nextWrapper =
           allowInterop((storage_interop.UploadTaskSnapshotJsImpl data) {
-        _changeController.add(new UploadTaskSnapshot.fromJsObject(data));
+        _changeController.add(UploadTaskSnapshot.get(data));
       });
 
       var errorWrapper = allowInterop((e) => _changeController.addError(e));
@@ -364,6 +324,8 @@ class UploadTask extends JsObjectWrapper<storage_interop.UploadTaskJsImpl> {
 /// See: <https://firebase.google.com/docs/reference/js/firebase.storage.UploadTaskSnapshot>.
 class UploadTaskSnapshot
     extends JsObjectWrapper<storage_interop.UploadTaskSnapshotJsImpl> {
+  static final _expando = new Expando<UploadTaskSnapshot>();
+
   /// The number of bytes that have been successfully transferred.
   int get bytesTransferred => jsObject.bytesTransferred;
 
@@ -371,35 +333,13 @@ class UploadTaskSnapshot
   /// completes. It is also accessible from [metadata].
   Uri get downloadURL => Uri.parse(jsObject.downloadURL);
 
-  FullMetadata _metadata;
-
   /// The metadata. Before the upload completes, it contains the metadata sent
   /// to the server. After the upload completes, it contains the metadata sent
   /// back from the server.
-  FullMetadata get metadata {
-    if (jsObject.metadata != null) {
-      if (_metadata != null) {
-        _metadata.jsObject = jsObject.metadata;
-      } else {
-        _metadata = new FullMetadata.fromJsObject(jsObject.metadata);
-      }
-    } else {
-      _metadata = null;
-    }
-    return _metadata;
-  }
-
-  StorageReference _ref;
+  FullMetadata get metadata => FullMetadata.get(jsObject.metadata);
 
   /// The StorageReference that spawned the current snapshot's upload task.
-  StorageReference get ref {
-    if (_ref != null) {
-      _ref.jsObject = jsObject.ref;
-    } else {
-      _ref = new StorageReference.fromJsObject(jsObject.ref);
-    }
-    return _ref;
-  }
+  StorageReference get ref => StorageReference.get(jsObject.ref);
 
   /// The actual task state.
   TaskState get state {
@@ -420,23 +360,23 @@ class UploadTaskSnapshot
     }
   }
 
-  UploadTask _task;
-
   /// The UploadTask for this snapshot.
-  UploadTask get task {
-    if (_task != null) {
-      _task.jsObject = jsObject.task;
-    } else {
-      _task = new UploadTask.fromJsObject(jsObject.task);
-    }
-    return _task;
-  }
+  UploadTask get task => UploadTask.get(jsObject.task);
 
   /// The total number of bytes to be uploaded.
   int get totalBytes => jsObject.totalBytes;
 
   /// Creates a new UploadTaskSnapshot from a [jsObject].
-  UploadTaskSnapshot.fromJsObject(
+  static UploadTaskSnapshot get(
+      storage_interop.UploadTaskSnapshotJsImpl jsObject) {
+    if (jsObject == null) {
+      return null;
+    }
+    return _expando[jsObject] ??=
+        new UploadTaskSnapshot._fromJsObject(jsObject);
+  }
+
+  UploadTaskSnapshot._fromJsObject(
       storage_interop.UploadTaskSnapshotJsImpl jsObject)
       : super.fromJsObject(jsObject);
 }

--- a/lib/src/top_level.dart
+++ b/lib/src/top_level.dart
@@ -11,8 +11,7 @@ export 'interop/firebase_interop.dart' show SDK_VERSION;
 /// A (read-only) array of all the initialized Apps.
 ///
 /// See: <https://firebase.google.com/docs/reference/js/firebase#.apps>.
-List<App> get apps =>
-    firebase.apps.map((jsApp) => new App.fromJsObject(jsApp)).toList();
+List<App> get apps => firebase.apps.map(App.get).toList();
 
 const String _defaultAppName = "[DEFAULT]";
 
@@ -29,7 +28,7 @@ App initializeApp(
   name ??= _defaultAppName;
 
   try {
-    return new App.fromJsObject(firebase.initializeApp(
+    return App.get(firebase.initializeApp(
         new firebase.FirebaseOptions(
             apiKey: apiKey,
             authDomain: authDomain,
@@ -45,8 +44,6 @@ App initializeApp(
   }
 }
 
-App _app;
-
 /// Retrieves an instance of an [App].
 ///
 /// With no arguments, this returns the default App. With a single
@@ -59,15 +56,8 @@ App _app;
 App app([String name]) {
   var jsObject = (name != null) ? firebase.app(name) : firebase.app();
 
-  if (_app != null) {
-    _app.jsObject = jsObject;
-  } else {
-    _app = new App.fromJsObject(jsObject);
-  }
-  return _app;
+  return App.get(jsObject);
 }
-
-Auth _auth;
 
 /// Gets the [Auth] object for the default App or a given App.
 ///
@@ -75,15 +65,8 @@ Auth _auth;
 Auth auth([App app]) {
   var jsObject = (app != null) ? firebase.auth(app.jsObject) : firebase.auth();
 
-  if (_auth != null) {
-    _auth.jsObject = jsObject;
-  } else {
-    _auth = new Auth.fromJsObject(jsObject);
-  }
-  return _auth;
+  return Auth.get(jsObject);
 }
-
-Database _database;
 
 /// Accesses the [Database] service for the default App or a given app.
 ///
@@ -95,15 +78,8 @@ Database database([App app]) {
   var jsObject =
       (app != null) ? firebase.database(app.jsObject) : firebase.database();
 
-  if (_database != null) {
-    _database.jsObject = jsObject;
-  } else {
-    _database = new Database.fromJsObject(jsObject);
-  }
-  return _database;
+  return Database.get(jsObject);
 }
-
-Storage _storage;
 
 /// The namespace for all the [Storage] functionality.
 ///
@@ -115,12 +91,7 @@ Storage storage([App app]) {
   var jsObject =
       (app != null) ? firebase.storage(app.jsObject) : firebase.storage();
 
-  if (_storage != null) {
-    _storage.jsObject = jsObject;
-  } else {
-    _storage = new Storage.fromJsObject(jsObject);
-  }
-  return _storage;
+  return Storage.get(jsObject);
 }
 
 /// Exception thrown when the firebase.js is not loaded.

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:js';
 
 import 'package:func/func.dart';
 import 'package:js/js.dart';

--- a/test/storage_test.dart
+++ b/test/storage_test.dart
@@ -63,6 +63,7 @@ void main() {
       expect(md.downloadURLs.single.pathSegments.last, contains(fileName));
       expect(md.customMetadata, isNotNull);
       expect(md.customMetadata['the answer'], '42');
+      expect(md.md5Hash, '8eRvMo5t7NVsZN1edh3Ctw==');
     });
 
     tearDown(() async {


### PR DESCRIPTION
If a wrapper needs to be cached, let's let the wrapper handle it
Also allows JsObjectWrapper.jsObject to be final