### PR TITLE
V4 update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 * Added more tests for V4 API.
 * `Auth`:
     * Implemented `PhoneAuthProvider` and `RecaptchaVerifier`.
+* `User`:
+    * Added `phoneNumber` property.
+    * Added `linkWithPhoneNumber`, `updatePhoneNumber` and `reauthenticateWithPhoneNumber` methods.
 
 ## 4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 4.1.0
 
+* Upgraded to Firebase JS API `4.2.0`.
 * Added `toJson` to `DataSnapshot` and `Query`. 
 * Added more tests for V4 API.
 * `Auth`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 4.1.0
 
 * Added `toJson` to `DataSnapshot` and `Query`. 
+* Added more tests for V4 API.
+* `Auth`:
+    * Implemented `PhoneAuthProvider` and `RecaptchaVerifier`.
 
 ## 4.0.0
 
@@ -21,7 +24,6 @@
   `linkAndRetrieveDataWithCredential`, and `toJson()`.
 
 * `Auth`: added `signInAndRetrieveDataWithCredential` and `onIdTokenChanged`.
-    * Implemented `PhoneAuthProvider` and `RecaptchaVerifier`.
 
 ## 3.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   `linkAndRetrieveDataWithCredential`, and `toJson()`.
 
 * `Auth`: added `signInAndRetrieveDataWithCredential` and `onIdTokenChanged`.
+    * Implemented `PhoneAuthProvider` and `RecaptchaVerifier`.
 
 ## 3.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * `User`:
     * Added `phoneNumber` property.
     * Added `linkWithPhoneNumber`, `updatePhoneNumber` and `reauthenticateWithPhoneNumber` methods.
+* New example demonstrating `PhoneAuthProvider` functionality in `example/auth_phone`.
 
 ## 4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * `Auth`:
     * Implemented `PhoneAuthProvider` and `RecaptchaVerifier`.
 * `User`:
-    * Added `phoneNumber` property.
+    * Added `phoneNumber` property to the `UserInfo`.
     * Added `linkWithPhoneNumber`, `updatePhoneNumber` and `reauthenticateWithPhoneNumber` methods.
 * New example demonstrating `PhoneAuthProvider` functionality in `example/auth_phone`.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You must include the original Firebase JavaScript source into your `.html` file
 to be able to use the library.
 
 ```html
-<script src="https://www.gstatic.com/firebasejs/4.1.3/firebase.js"></script>
+<script src="https://www.gstatic.com/firebasejs/4.2.0/firebase.js"></script>
 ```
 
 ### Use it

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The following providers need to be enabled in Firebase console,
 
 * E-mail/password
 * Anonymous
+* Phone
 
 ### Database tests and example
 

--- a/example/auth/index.html
+++ b/example/auth/index.html
@@ -33,7 +33,7 @@
   <button id="verify_email" style="display: none">Verify email</button>
   <a href="#" id="logout_btn" style="display: none">Log out</a>
 </div>
-<script src="https://www.gstatic.com/firebasejs/4.1.3/firebase.js"></script>
+<script src="https://www.gstatic.com/firebasejs/4.2.0/firebase.js"></script>
 <script src="index.dart" type="application/dart"></script>
 <script src="packages/browser/dart.js"></script>
 </body>

--- a/example/auth_phone/index.dart
+++ b/example/auth_phone/index.dart
@@ -72,7 +72,19 @@ class PhoneAuthApp {
   }
 
   _initVerifier() {
-    verifier = new fb.RecaptchaVerifier("recaptcha-container")..render();
+    // This is anonymous recaptcha - size has to be defined
+    verifier = new fb.RecaptchaVerifier("register", {
+      "size": "invisible",
+      "callback": (resp) {
+        print("reCAPTCHA solved, allow signInWithPhoneNumber.");
+      },
+      "expired-callback": () {
+        print("Response expired. Ask user to solve reCAPTCHA again.");
+      }
+    });
+
+    // Use this if you want to use recaptcha widget directly
+    //verifier = new fb.RecaptchaVerifier("recaptcha-container")..render();
   }
 
   _resetVerifier() {
@@ -117,10 +129,10 @@ class PhoneAuthApp {
       authInfo.style.display = "block";
 
       var data = <String, dynamic>{
-        'email': user.email,
-        'emailVerified': user.emailVerified,
-        'isAnonymous': user.isAnonymous,
-        'phoneNumber': user.phoneNumber
+        "email": user.email,
+        "emailVerified": user.emailVerified,
+        "isAnonymous": user.isAnonymous,
+        "phoneNumber": user.phoneNumber
       };
 
       data.forEach((k, v) {
@@ -129,12 +141,12 @@ class PhoneAuthApp {
 
           row.addCell()
             ..text = k
-            ..classes.add('header');
+            ..classes.add("header");
           row.addCell()..text = "$v";
         }
       });
 
-      print('User.toJson:');
+      print("User.toJson:");
       print(const JsonEncoder.withIndent(' ').convert(user));
     } else {
       registerForm.style.display = "block";

--- a/example/auth_phone/index.dart
+++ b/example/auth_phone/index.dart
@@ -1,0 +1,138 @@
+import 'dart:convert';
+import 'dart:html';
+
+import 'package:firebase/firebase.dart' as fb;
+import 'package:firebase/src/assets/assets.dart';
+
+main() async {
+  //Use for firebase package development only
+  await config();
+
+  try {
+    fb.initializeApp(
+        apiKey: apiKey,
+        authDomain: authDomain,
+        databaseURL: databaseUrl,
+        storageBucket: storageBucket);
+
+    new PhoneAuthApp();
+  } on fb.FirebaseJsNotLoadedException catch (e) {
+    print(e);
+  }
+}
+
+class PhoneAuthApp {
+  final fb.Auth auth;
+  final fb.RecaptchaVerifier verifier;
+
+  final FormElement registerForm, verificationForm;
+  final InputElement phone, code;
+  final AnchorElement logout;
+  final TableElement authInfo;
+  final ParagraphElement error;
+
+  fb.ConfirmationResult _confirmationResult;
+
+  PhoneAuthApp()
+      : this.auth = fb.auth(),
+        this.verifier =
+            new fb.RecaptchaVerifier("recaptcha-container"),
+        this.logout = querySelector("#logout_btn"),
+        this.error = querySelector(".error"),
+        this.authInfo = querySelector("#auth_info"),
+        this.phone = querySelector("#phone"),
+        this.code = querySelector("#code"),
+        this.registerForm = querySelector("#register_form"),
+        this.verificationForm = querySelector("#verification_form"){
+    logout.onClick.listen((e) {
+      e.preventDefault();
+      auth.signOut();
+    });
+
+    this.registerForm.onSubmit.listen((e) {
+      e.preventDefault();
+      var phoneValue = phone.value.trim();
+      _registerUser(phoneValue);
+    });
+
+    this.verificationForm.onSubmit.listen((e) {
+      e.preventDefault();
+      var codeValue = code.value.trim();
+      _verifyUser(codeValue);
+    });
+
+    // After opening
+    if (auth.currentUser != null) {
+      _setLayout(auth.currentUser);
+    } else {
+      this.verifier.render();
+    }
+
+    // When auth state changes
+    auth.onAuthStateChanged.listen((e) => _setLayout(e));
+  }
+
+  _registerUser(String phone) async {
+    if (phone.isNotEmpty) {
+      try {
+        _confirmationResult = await auth.signInWithPhoneNumber(phone, verifier);
+        verificationForm.style.display = "block";
+        registerForm.style.display = "none";
+      } catch (e) {
+        error.text = e.toString();
+      }
+    } else {
+      error.text = "Please fill correct phone number.";
+    }
+  }
+
+  _verifyUser(String code) async {
+    if (code.isNotEmpty) {
+      try {
+        await _confirmationResult.confirm(code);
+      } catch (e) {
+        error.text = e.toString();
+      }
+    } else {
+      error.text = "Please fill correct verification code.";
+    }
+  }
+
+  void _setLayout(fb.User user) {
+    if (user != null) {
+      registerForm.style.display = "none";
+      verificationForm.style.display = "none";
+      logout.style.display = "block";
+      phone.value = "";
+      code.value = "";
+      error.text = "";
+      authInfo.style.display = "block";
+
+      var data = <String, dynamic>{
+        'email': user.email,
+        'emailVerified': user.emailVerified,
+        'isAnonymous': user.isAnonymous,
+        'phoneNumber': user.phoneNumber
+      };
+
+      data.forEach((k, v) {
+        if (v != null) {
+          var row = authInfo.addRow();
+
+          row.addCell()
+            ..text = k
+            ..classes.add('header');
+          row.addCell()..text = "$v";
+        }
+      });
+
+      print('User.toJson:');
+      print(const JsonEncoder.withIndent(' ').convert(user));
+    } else {
+      registerForm.style.display = "block";
+      authInfo.style.display = "none";
+      logout.style.display = "none";
+      authInfo.children.clear();
+    }
+  }
+}

--- a/example/auth_phone/index.dart
+++ b/example/auth_phone/index.dart
@@ -23,7 +23,6 @@ main() async {
 
 class PhoneAuthApp {
   final fb.Auth auth;
-  final fb.RecaptchaVerifier verifier;
 
   final FormElement registerForm, verificationForm;
   final InputElement phone, code;
@@ -31,22 +30,22 @@ class PhoneAuthApp {
   final TableElement authInfo;
   final ParagraphElement error;
 
+  fb.RecaptchaVerifier verifier;
   fb.ConfirmationResult _confirmationResult;
 
   PhoneAuthApp()
       : this.auth = fb.auth(),
-        this.verifier =
-            new fb.RecaptchaVerifier("recaptcha-container"),
         this.logout = querySelector("#logout_btn"),
         this.error = querySelector(".error"),
         this.authInfo = querySelector("#auth_info"),
         this.phone = querySelector("#phone"),
         this.code = querySelector("#code"),
         this.registerForm = querySelector("#register_form"),
-        this.verificationForm = querySelector("#verification_form"){
+        this.verificationForm = querySelector("#verification_form") {
     logout.onClick.listen((e) {
       e.preventDefault();
       auth.signOut();
+      _resetVerifier();
     });
 
     this.registerForm.onSubmit.listen((e) {
@@ -65,11 +64,20 @@ class PhoneAuthApp {
     if (auth.currentUser != null) {
       _setLayout(auth.currentUser);
     } else {
-      this.verifier.render();
+      _initVerifier();
     }
 
     // When auth state changes
     auth.onAuthStateChanged.listen((e) => _setLayout(e));
+  }
+
+  _initVerifier() {
+    verifier = new fb.RecaptchaVerifier("recaptcha-container")..render();
+  }
+
+  _resetVerifier() {
+    verifier.clear();
+    _initVerifier();
   }
 
   _registerUser(String phone) async {

--- a/example/auth_phone/index.dart
+++ b/example/auth_phone/index.dart
@@ -23,7 +23,6 @@ main() async {
 
 class PhoneAuthApp {
   final fb.Auth auth;
-
   final FormElement registerForm, verificationForm;
   final InputElement phone, code;
   final AnchorElement logout;
@@ -31,7 +30,7 @@ class PhoneAuthApp {
   final ParagraphElement error;
 
   fb.RecaptchaVerifier verifier;
-  fb.ConfirmationResult _confirmationResult;
+  fb.ConfirmationResult confirmationResult;
 
   PhoneAuthApp()
       : this.auth = fb.auth(),
@@ -72,7 +71,7 @@ class PhoneAuthApp {
   }
 
   _initVerifier() {
-    // This is anonymous recaptcha - size has to be defined
+    // This is anonymous recaptcha - size must be defined
     verifier = new fb.RecaptchaVerifier("register", {
       "size": "invisible",
       "callback": (resp) {
@@ -95,7 +94,7 @@ class PhoneAuthApp {
   _registerUser(String phone) async {
     if (phone.isNotEmpty) {
       try {
-        _confirmationResult = await auth.signInWithPhoneNumber(phone, verifier);
+        confirmationResult = await auth.signInWithPhoneNumber(phone, verifier);
         verificationForm.style.display = "block";
         registerForm.style.display = "none";
       } catch (e) {
@@ -107,9 +106,9 @@ class PhoneAuthApp {
   }
 
   _verifyUser(String code) async {
-    if (code.isNotEmpty) {
+    if (code.isNotEmpty && confirmationResult != null) {
       try {
-        await _confirmationResult.confirm(code);
+        await confirmationResult.confirm(code);
       } catch (e) {
         error.text = e.toString();
       }

--- a/example/auth_phone/index.html
+++ b/example/auth_phone/index.html
@@ -39,7 +39,7 @@
   </table>
   <a href="#" id="logout_btn" style="display: none">Log out</a>
 </div>
-<script src="https://www.gstatic.com/firebasejs/4.1.3/firebase.js"></script>
+<script src="https://www.gstatic.com/firebasejs/4.2.0/firebase.js"></script>
 <script src="index.dart" type="application/dart"></script>
 <script src="packages/browser/dart.js"></script>
 </body>

--- a/example/auth_phone/index.html
+++ b/example/auth_phone/index.html
@@ -24,6 +24,7 @@
   <p class="error"></p>
   <h2>Register with phone number</h2>
   <form id="register_form" style="display: none">
+    <label for="phone">Your phone number in E.164 format (e.g. +16505550101).</label><br>
     <input type="text" placeholder="Your phone number" id="phone">
     <div id="recaptcha-container"></div>
     <input type="submit" value="Register me" id="register">

--- a/example/auth_phone/index.html
+++ b/example/auth_phone/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <title>Phone auth demo</title>
   <style type="text/css">
-    .error p {
+    .error {
       color: red;
     }
     #auth_info td {

--- a/example/auth_phone/index.html
+++ b/example/auth_phone/index.html
@@ -26,7 +26,7 @@
   <form id="register_form" style="display: none">
     <input type="text" placeholder="Your phone number" id="phone">
     <div id="recaptcha-container"></div>
-    <input type="submit" value="Register me">
+    <input type="submit" value="Register me" id="register">
   </form>
   <form id="verification_form" style="display: none">
     <h3>Verification code</h3>

--- a/example/auth_phone/index.html
+++ b/example/auth_phone/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Phone auth demo</title>
+  <style type="text/css">
+    .error p {
+      color: red;
+    }
+    #auth_info td {
+      padding: 1px;
+    }
+    #auth_info td.header {
+      font-weight: bold;
+      text-align: right;
+    }
+  </style>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+        integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+</head>
+<body>
+<div class="container">
+  <h1>Phone auth demo</h1>
+  <p class="error"></p>
+  <h2>Register with phone number</h2>
+  <form id="register_form" style="display: none">
+    <input type="text" placeholder="Your phone number" id="phone">
+    <div id="recaptcha-container"></div>
+    <input type="submit" value="Register me">
+  </form>
+  <form id="verification_form" style="display: none">
+    <h3>Verification code</h3>
+    <p></p>
+    <input type="text" placeholder="Your verification code" id="code">
+    <input type="submit" value="Verify me">
+  </form>
+  <table id="auth_info" style="display: none">
+  </table>
+  <a href="#" id="logout_btn" style="display: none">Log out</a>
+</div>
+<script src="https://www.gstatic.com/firebasejs/4.1.3/firebase.js"></script>
+<script src="index.dart" type="application/dart"></script>
+<script src="packages/browser/dart.js"></script>
+</body>
+</html>

--- a/example/index.html
+++ b/example/index.html
@@ -11,6 +11,7 @@
   <h1>Examples</h1>
   <ul>
     <li><a href="auth/index.html">auth</a></li>
+    <li><a href="auth_phone/index.html">phone auth</a></li>
     <li><a href="realtime_database/index.html">database</a></li>
     <li><a href="storage/index.html">storage</a></li>
   </ul>

--- a/example/realtime_database/index.html
+++ b/example/realtime_database/index.html
@@ -46,7 +46,7 @@
     <input type="submit" value="Send" id="submit" disabled>
   </form>
 </div>
-<script src="https://www.gstatic.com/firebasejs/4.1.3/firebase.js"></script>
+<script src="https://www.gstatic.com/firebasejs/4.2.0/firebase.js"></script>
 <script src="index.dart" type="application/dart"></script>
 <script src="packages/browser/dart.js"></script>
 </body>

--- a/example/storage/index.html
+++ b/example/storage/index.html
@@ -14,7 +14,7 @@
   </form>
   <p id="message"></p>
 </div>
-<script src="https://www.gstatic.com/firebasejs/4.1.3/firebase.js"></script>
+<script src="https://www.gstatic.com/firebasejs/4.2.0/firebase.js"></script>
 <script src="index.dart" type="application/dart"></script>
 <script src="packages/browser/dart.js"></script>
 </body>

--- a/lib/src/auth.dart
+++ b/lib/src/auth.dart
@@ -200,6 +200,9 @@ class Auth extends JsObjectWrapper<AuthJsImpl> {
 
   /// Sends events when the users sign-in state changes.
   ///
+  /// After 4.0.0, this is only triggered on sign-in or sign-out.
+  /// To keep the old behavior, see [onIdTokenChanged].
+  ///
   /// If the value is `null`, there is no signed-in user.
   Stream<User> get onAuthStateChanged {
     if (_changeController == null) {
@@ -229,8 +232,12 @@ class Auth extends JsObjectWrapper<AuthJsImpl> {
   Func0 _onIdTokenChangedUnsubscribe;
   StreamController<User> _idTokenChangedController;
 
-  /// Sends events when the signed-in user's ID token, which includes sign-in,
-  /// sign-out, and token refresh events.
+  /// Sends events for changes to the signed-in user's ID token,
+  /// which includes sign-in, sign-out, and token refresh events.
+  ///
+  /// This method has the same behavior as [onAuthStateChanged] had prior to 4.0.0.
+  ///
+  /// If the value is `null`, there is no signed-in user.
   Stream<User> get onIdTokenChanged {
     if (_idTokenChangedController == null) {
       var nextWrapper = allowInterop((firebase_interop.UserJsImpl user) {

--- a/lib/src/auth.dart
+++ b/lib/src/auth.dart
@@ -58,6 +58,11 @@ class User extends UserInfo<firebase_interop.UserJsImpl> {
   /// Refresh token for the user account.
   String get refreshToken => jsObject.refreshToken;
 
+  /// The phone number normalized based on the E.164 standard (e.g. +16505550101)
+  /// for the current user. This is [:null:] if the user has no phone credential
+  /// linked to the account.
+  String get phoneNumber => jsObject.phoneNumber;
+
   /// Creates a new User from a [jsObject].
   ///
   /// If an instance of [User] is already associated with [jsObject], it is
@@ -107,6 +112,15 @@ class User extends UserInfo<firebase_interop.UserJsImpl> {
       handleThenableWithMapper(
           jsObject.linkWithCredential(credential), User.get);
 
+  /// Links the user account with the given [phoneNumber] in E.164 format
+  /// (e.g. +16505550101) and [applicationVerifier].
+  Future<ConfirmationResult> linkWithPhoneNumber(
+          String phoneNumber, ApplicationVerifier applicationVerifier) =>
+      handleThenableWithMapper(
+          jsObject.linkWithPhoneNumber(
+              phoneNumber, applicationVerifier.jsObject),
+          (c) => new ConfirmationResult.fromJsObject(c));
+
   /// Links the authenticated [provider] to the user account using
   /// a pop-up based OAuth flow.
   /// It returns the [UserCredential] information if linking is successful.
@@ -128,6 +142,18 @@ class User extends UserInfo<firebase_interop.UserJsImpl> {
       handleThenableWithMapper(
           jsObject.reauthenticateAndRetrieveDataWithCredential(credential),
           (o) => new UserCredential.fromJsObject(o));
+
+  /// Re-authenticates a user using a fresh credential.
+  /// Use before operations such as [updatePassword] that require tokens
+  /// from recent sign-in attempts.
+  ///
+  /// The user's phone number is in E.164 format (e.g. +16505550101).
+  Future<ConfirmationResult> reauthenticateWithPhoneNumber(
+          String phoneNumber, ApplicationVerifier applicationVerifier) =>
+      handleThenableWithMapper(
+          jsObject.reauthenticateWithPhoneNumber(
+              phoneNumber, applicationVerifier.jsObject),
+          (c) => new ConfirmationResult.fromJsObject(c));
 
   /// Re-authenticates a user using a fresh [credential]. Should be used
   /// before operations such as [updatePassword()] that require tokens
@@ -168,6 +194,10 @@ class User extends UserInfo<firebase_interop.UserJsImpl> {
   /// to authenticate again and then use [reauthenticate()].
   Future updatePassword(String newPassword) =>
       handleThenable(jsObject.updatePassword(newPassword));
+
+  /// Updates the user's phone number.
+  Future updatePhoneNumber(AuthCredential phoneCredential) =>
+      handleThenable(jsObject.updatePhoneNumber(phoneCredential));
 
   /// Updates a user's [profile] data.
   /// UserProfile has a displayName and photoURL.

--- a/lib/src/auth.dart
+++ b/lib/src/auth.dart
@@ -752,7 +752,7 @@ class AdditionalUserInfo extends JsObjectWrapper<AdditionalUserInfoJsImpl> {
   String get providerId => jsObject.providerId;
 
   /// Returns the profile.
-  Map get profile => dartify(jsObject.profile);
+  Map<String, dynamic> get profile => dartify(jsObject.profile);
 
   /// Returns the user name.
   String get username => jsObject.username;

--- a/lib/src/auth.dart
+++ b/lib/src/auth.dart
@@ -177,6 +177,7 @@ class User extends UserInfo<firebase_interop.UserJsImpl> {
   Future updateProfile(firebase_interop.UserProfile profile) =>
       handleThenable(jsObject.updateProfile(profile));
 
+  /// Returns a JSON-serializable representation of this object.
   Map<String, dynamic> toJson() => dartify(jsObject.toJSON());
 
   @override
@@ -565,8 +566,10 @@ class PhoneAuthProvider extends AuthProvider<PhoneAuthProviderJsImpl> {
 
   /// Creates a new PhoneAuthProvider with the optional [Auth] instance
   /// in which sign-ins should occur.
-  factory PhoneAuthProvider([Auth auth]) => new PhoneAuthProvider.fromJsObject(
-      new PhoneAuthProviderJsImpl(auth?.jsObject));
+  factory PhoneAuthProvider([Auth auth]) =>
+      new PhoneAuthProvider.fromJsObject((auth != null)
+          ? new PhoneAuthProviderJsImpl(auth.jsObject)
+          : new PhoneAuthProviderJsImpl());
 
   /// Creates a new PhoneAuthProvider from a [jsObject].
   PhoneAuthProvider.fromJsObject(PhoneAuthProviderJsImpl jsObject)
@@ -579,17 +582,16 @@ class PhoneAuthProvider extends AuthProvider<PhoneAuthProviderJsImpl> {
   ///
   /// For abuse prevention, this method also requires an [ApplicationVerifier].
   Future<String> verifyPhoneNumber(
-      String phoneNumber, ApplicationVerifier applicationVerifier) =>
+          String phoneNumber, ApplicationVerifier applicationVerifier) =>
       handleThenable(jsObject.verifyPhoneNumber(
           phoneNumber, applicationVerifier.jsObject));
 
   /// Creates a phone auth credential given the verification ID
   /// from [verifyPhoneNumber] and the [verificationCode] that was sent to the
   /// user's mobile device.
-  static Future<AuthCredential> credential(
+  static AuthCredential credential(
           String verificationId, String verificationCode) =>
-      handleThenable(
-          PhoneAuthProviderJsImpl.credential(verificationId, verificationCode));
+      PhoneAuthProviderJsImpl.credential(verificationId, verificationCode);
 }
 
 /// A verifier for domain verification and abuse prevention.
@@ -618,8 +620,14 @@ class RecaptchaVerifier extends ApplicationVerifier<RecaptchaVerifierJsImpl> {
   /// Creates a new RecaptchaVerifier from [container], [parameters] and [app].
   factory RecaptchaVerifier(container,
           [Map<String, dynamic> parameters, App app]) =>
-      new RecaptchaVerifier.fromJsObject(new RecaptchaVerifierJsImpl(
-          container, jsify(parameters), app?.jsObject));
+      (parameters != null)
+          ? ((app != null)
+              ? new RecaptchaVerifier.fromJsObject(new RecaptchaVerifierJsImpl(
+                  container, jsify(parameters), app.jsObject))
+              : new RecaptchaVerifier.fromJsObject(
+                  new RecaptchaVerifierJsImpl(container, jsify(parameters))))
+          : new RecaptchaVerifier.fromJsObject(
+              new RecaptchaVerifierJsImpl(container));
 
   /// Creates a new RecaptchaVerifier from a [jsObject].
   RecaptchaVerifier.fromJsObject(RecaptchaVerifierJsImpl jsObject)

--- a/lib/src/auth.dart
+++ b/lib/src/auth.dart
@@ -697,6 +697,8 @@ class ConfirmationResult extends JsObjectWrapper<ConfirmationResultJsImpl> {
 /// A structure containing a [User], an [AuthCredential] and [operationType].
 /// operationType could be 'signIn' for a sign-in operation, 'link' for a
 /// linking operation and 'reauthenticate' for a reauthentication operation.
+///
+/// See: <https://firebase.google.com/docs/reference/js/firebase.auth#.UserCredential>
 class UserCredential extends JsObjectWrapper<UserCredentialJsImpl> {
   /// Returns the user.
   User get user => User.get(jsObject.user);
@@ -706,6 +708,9 @@ class UserCredential extends JsObjectWrapper<UserCredentialJsImpl> {
 
   /// Returns the operation type.
   String get operationType => jsObject.operationType;
+
+  /// Returns additional user information from a federated identity provider.
+  AdditionalUserInfoJsImpl get additionalUserInfo => jsObject.additionalUserInfo;
 
   /// Creates a new UserCredential from a [jsObject].
   UserCredential.fromJsObject(UserCredentialJsImpl jsObject)

--- a/lib/src/auth.dart
+++ b/lib/src/auth.dart
@@ -735,10 +735,29 @@ class UserCredential extends JsObjectWrapper<UserCredentialJsImpl> {
   String get operationType => jsObject.operationType;
 
   /// Returns additional user information from a federated identity provider.
-  AdditionalUserInfoJsImpl get additionalUserInfo =>
-      jsObject.additionalUserInfo;
+  AdditionalUserInfo get additionalUserInfo =>
+      new AdditionalUserInfo.fromJsObject(jsObject.additionalUserInfo);
 
   /// Creates a new UserCredential from a [jsObject].
   UserCredential.fromJsObject(UserCredentialJsImpl jsObject)
+      : super.fromJsObject(jsObject);
+}
+
+/// A structure containing additional user information from
+/// a federated identity provider.
+///
+/// See: <https://firebase.google.com/docs/reference/js/firebase.auth#.AdditionalUserInfo>
+class AdditionalUserInfo extends JsObjectWrapper<AdditionalUserInfoJsImpl> {
+  /// Returns the provider id.
+  String get providerId => jsObject.providerId;
+
+  /// Returns the profile.
+  Map get profile => dartify(jsObject.profile);
+
+  /// Returns the user name.
+  String get username => jsObject.username;
+
+  /// Creates a new AdditionalUserInfo from a [jsObject].
+  AdditionalUserInfo.fromJsObject(AdditionalUserInfoJsImpl jsObject)
       : super.fromJsObject(jsObject);
 }

--- a/lib/src/auth.dart
+++ b/lib/src/auth.dart
@@ -24,6 +24,9 @@ class UserInfo<T extends firebase_interop.UserInfoJsImpl>
   /// User's e-mail address.
   String get email => jsObject.email;
 
+  /// The user's E.164 formatted phone number (if available).
+  String get phoneNumber => jsObject.phoneNumber;
+
   /// User's profile picture URL.
   String get photoURL => jsObject.photoURL;
 
@@ -57,11 +60,6 @@ class User extends UserInfo<firebase_interop.UserJsImpl> {
 
   /// Refresh token for the user account.
   String get refreshToken => jsObject.refreshToken;
-
-  /// The phone number normalized based on the E.164 standard (e.g. +16505550101)
-  /// for the current user. This is [:null:] if the user has no phone credential
-  /// linked to the account.
-  String get phoneNumber => jsObject.phoneNumber;
 
   /// Creates a new User from a [jsObject].
   ///

--- a/lib/src/auth.dart
+++ b/lib/src/auth.dart
@@ -557,25 +557,39 @@ class TwitterAuthProvider extends AuthProvider<TwitterAuthProviderJsImpl> {
       TwitterAuthProviderJsImpl.credential(token, secret);
 }
 
-/// Phone auth provider.
+/// Phone number auth provider.
 ///
 /// See: <https://firebase.google.com/docs/reference/js/firebase.auth.PhoneAuthProvider>.
 class PhoneAuthProvider extends AuthProvider<PhoneAuthProviderJsImpl> {
   static String get PROVIDER_ID => PhoneAuthProviderJsImpl.PROVIDER_ID;
 
-  factory PhoneAuthProvider() =>
-      new PhoneAuthProvider.fromJsObject(new PhoneAuthProviderJsImpl());
+  /// Creates a new PhoneAuthProvider with the optional [Auth] instance
+  /// in which sign-ins should occur.
+  factory PhoneAuthProvider([Auth auth]) => new PhoneAuthProvider.fromJsObject(
+      new PhoneAuthProviderJsImpl(auth?.jsObject));
 
+  /// Creates a new PhoneAuthProvider from a [jsObject].
   PhoneAuthProvider.fromJsObject(PhoneAuthProviderJsImpl jsObject)
       : super.fromJsObject(jsObject);
 
-//(TODO)
-// https://firebase.google.com/docs/reference/js/firebase.auth.PhoneAuthProvider#verifyPhoneNumber
-// verifyPhoneNumber
+  /// Starts a phone number authentication flow by sending a verification code
+  /// to the given [phoneNumber] in E.164 format (e.g. +16505550101).
+  /// Returns an ID that can be passed to [PhoneAuthProvider.credential]
+  /// to identify this flow.
+  ///
+  /// For abuse prevention, this method also requires an [ApplicationVerifier].
+  Future<String> verifyPhoneNumber(
+      String phoneNumber, ApplicationVerifier applicationVerifier) =>
+      handleThenable(jsObject.verifyPhoneNumber(
+          phoneNumber, applicationVerifier.jsObject));
 
-//(TODO)
-// https://firebase.google.com/docs/reference/js/firebase.auth.PhoneAuthProvider#.credential
-// credential
+  /// Creates a phone auth credential given the verification ID
+  /// from [verifyPhoneNumber] and the [verificationCode] that was sent to the
+  /// user's mobile device.
+  static Future<AuthCredential> credential(
+          String verificationId, String verificationCode) =>
+      handleThenable(
+          PhoneAuthProviderJsImpl.credential(verificationId, verificationCode));
 }
 
 /// A verifier for domain verification and abuse prevention.

--- a/lib/src/auth.dart
+++ b/lib/src/auth.dart
@@ -710,7 +710,8 @@ class UserCredential extends JsObjectWrapper<UserCredentialJsImpl> {
   String get operationType => jsObject.operationType;
 
   /// Returns additional user information from a federated identity provider.
-  AdditionalUserInfoJsImpl get additionalUserInfo => jsObject.additionalUserInfo;
+  AdditionalUserInfoJsImpl get additionalUserInfo =>
+      jsObject.additionalUserInfo;
 
   /// Creates a new UserCredential from a [jsObject].
   UserCredential.fromJsObject(UserCredentialJsImpl jsObject)

--- a/lib/src/auth.dart
+++ b/lib/src/auth.dart
@@ -649,8 +649,33 @@ abstract class ApplicationVerifier<T extends ApplicationVerifierJsImpl>
 /// See: <https://firebase.google.com/docs/reference/js/firebase.auth.RecaptchaVerifier>
 /// See: <https://www.google.com/recaptcha/>
 class RecaptchaVerifier extends ApplicationVerifier<RecaptchaVerifierJsImpl> {
-  // TODO what if there is a callback in the parameters?
   /// Creates a new RecaptchaVerifier from [container], [parameters] and [app].
+  ///
+  /// The [container] has different meaning depending on whether the reCAPTCHA
+  /// is hidden or visible. For a visible reCAPTCHA it must be empty.
+  /// If a string is used, it has to correspond to an element ID.
+  /// The corresponding element must also must be in the DOM at the time
+  /// of initialization.
+  ///
+  /// The [parameters] are optional [Map] of Recaptcha parameters.
+  /// See: <https://developers.google.com/recaptcha/docs/display#render_param>.
+  /// All parameters are accepted except for the sitekey.
+  /// Firebase Auth backend provisions a reCAPTCHA for each project
+  /// and will configure this upon rendering.
+  /// For an invisible reCAPTCHA, a size key must have the value 'invisible'.
+  ///
+  /// The [app] is the corresponding Firebase app.
+  /// If none is provided, the default Firebase App instance is used.
+  ///
+  ///     verifier = new fb.RecaptchaVerifier("register", {
+  ///       "size": "invisible",
+  ///       "callback": (resp) {
+  ///         print("Successful reCAPTCHA response");
+  ///       },
+  ///       "expired-callback": () {
+  ///         print("Response expired");
+  ///       }
+  ///     });
   factory RecaptchaVerifier(container,
           [Map<String, dynamic> parameters, App app]) =>
       (parameters != null)

--- a/lib/src/auth.dart
+++ b/lib/src/auth.dart
@@ -96,6 +96,9 @@ class User extends UserInfo<firebase_interop.UserJsImpl> {
   ///
   /// Returns the current token if it has not expired, otherwise this will
   /// refresh the token and return a new one.
+  ///
+  /// It forces refresh regardless of token expiration if [forceRefresh]
+  /// parameter is [true].
   Future<String> getIdToken([bool forceRefresh = false]) =>
       handleThenable(jsObject.getIdToken(forceRefresh));
 

--- a/lib/src/interop/auth_interop.dart
+++ b/lib/src/interop/auth_interop.dart
@@ -31,9 +31,8 @@ abstract class AuthJsImpl {
   external PromiseJsImpl<UserJsImpl> signInWithCustomToken(String token);
   external PromiseJsImpl<UserJsImpl> signInWithEmailAndPassword(
       String email, String password);
-  @Deprecated('not impld')
-  external PromiseJsImpl signInWithPhoneNumber(
-      String phoneNumber, /* ApplicationVerifier */ applicationVerifier);
+  external PromiseJsImpl<ConfirmationResultJsImpl> signInWithPhoneNumber(
+      String phoneNumber, ApplicationVerifierJsImpl applicationVerifier);
   external PromiseJsImpl<UserCredentialJsImpl> signInWithPopup(
       AuthProviderJsImpl provider);
   external PromiseJsImpl signInWithRedirect(AuthProviderJsImpl provider);
@@ -103,15 +102,32 @@ class TwitterAuthProviderJsImpl extends AuthProviderJsImpl {
 
 @JS('PhoneAuthProvider')
 class PhoneAuthProviderJsImpl extends AuthProviderJsImpl {
-  external factory PhoneAuthProviderJsImpl();
+  external factory PhoneAuthProviderJsImpl([AuthJsImpl auth]);
   external static String get PROVIDER_ID;
-
-  /// The user's [phoneNumber] in E.164 format (e.g. +16505550101).
-  external verifyPhoneNumber(String phoneNumber, applicationVerifier);
-
-  // https://firebase.google.com/docs/reference/js/firebase.auth.PhoneAuthProvider#.credential
-  external static PromiseJsImpl<AuthCredential> credential(
+  external PromiseJsImpl verifyPhoneNumber(
+      String phoneNumber, ApplicationVerifierJsImpl applicationVerifier);
+  external static AuthCredential credential(
       String verificationId, String verificationCode);
+}
+
+@JS('ApplicationVerifier')
+abstract class ApplicationVerifierJsImpl {
+  external String get type;
+  external PromiseJsImpl<String> verify();
+}
+
+@JS('RecaptchaVerifier')
+class RecaptchaVerifierJsImpl extends ApplicationVerifierJsImpl {
+  external factory RecaptchaVerifierJsImpl(container,
+      [Object parameters, AppJsImpl app]);
+  external clear();
+  external PromiseJsImpl<num> render();
+}
+
+@JS('ConfirmationResult')
+abstract class ConfirmationResultJsImpl {
+  external String get verificationId;
+  external PromiseJsImpl<UserCredentialJsImpl> confirm(String verificationCode);
 }
 
 /// A response from [Auth.checkActionCode].

--- a/lib/src/interop/auth_interop.dart
+++ b/lib/src/interop/auth_interop.dart
@@ -104,9 +104,9 @@ class TwitterAuthProviderJsImpl extends AuthProviderJsImpl {
 class PhoneAuthProviderJsImpl extends AuthProviderJsImpl {
   external factory PhoneAuthProviderJsImpl([AuthJsImpl auth]);
   external static String get PROVIDER_ID;
-  external PromiseJsImpl verifyPhoneNumber(
+  external PromiseJsImpl<String> verifyPhoneNumber(
       String phoneNumber, ApplicationVerifierJsImpl applicationVerifier);
-  external static AuthCredential credential(
+  external static PromiseJsImpl<AuthCredential> credential(
       String verificationId, String verificationCode);
 }
 

--- a/lib/src/interop/auth_interop.dart
+++ b/lib/src/interop/auth_interop.dart
@@ -160,10 +160,10 @@ class ActionCodeEmail {
 @JS()
 @anonymous
 class UserCredentialJsImpl {
-  external AdditionalUserInfoJsImpl get additionalUserInfo;
   external UserJsImpl get user;
   external AuthCredential get credential;
   external String get operationType;
+  external AdditionalUserInfoJsImpl get additionalUserInfo;
 }
 
 /// https://firebase.google.com/docs/reference/js/firebase.auth#.AdditionalUserInfo

--- a/lib/src/interop/auth_interop.dart
+++ b/lib/src/interop/auth_interop.dart
@@ -106,7 +106,8 @@ class PhoneAuthProviderJsImpl extends AuthProviderJsImpl {
   external static String get PROVIDER_ID;
   external PromiseJsImpl<String> verifyPhoneNumber(
       String phoneNumber, ApplicationVerifierJsImpl applicationVerifier);
-  external static PromiseJsImpl<AuthCredential> credential(
+  // TODO official documentation says PromiseJsImpl<AuthCredential> return type
+  external static AuthCredential credential(
       String verificationId, String verificationCode);
 }
 

--- a/lib/src/interop/database_interop.dart
+++ b/lib/src/interop/database_interop.dart
@@ -72,7 +72,6 @@ abstract class QueryJsImpl {
   external Object toJSON();
   @override
   external String toString();
-  external Object toJSON();
 }
 
 @JS('DataSnapshot')

--- a/lib/src/interop/database_interop.dart
+++ b/lib/src/interop/database_interop.dart
@@ -69,6 +69,7 @@ abstract class QueryJsImpl {
   external QueryJsImpl orderByPriority();
   external QueryJsImpl orderByValue();
   external QueryJsImpl startAt(value, [String key]);
+  external Object toJSON();
   @override
   external String toString();
 }
@@ -88,6 +89,7 @@ abstract class DataSnapshotJsImpl {
   external bool hasChildren();
   external int numChildren();
   external dynamic val();
+  external Object toJSON();
 }
 
 @JS('OnDisconnect')

--- a/lib/src/interop/firebase_interop.dart
+++ b/lib/src/interop/firebase_interop.dart
@@ -36,8 +36,8 @@ abstract class UserJsImpl extends UserInfoJsImpl {
   external bool get isAnonymous;
   external List<UserInfoJsImpl> get providerData;
   external String get refreshToken;
-  external PromiseJsImpl delete();
   external String get phoneNumber;
+  external PromiseJsImpl delete();
   @Deprecated('Use `getIdToken` instead.')
   external PromiseJsImpl<String> getToken([bool opt_forceRefresh]);
   external PromiseJsImpl<String> getIdToken([bool opt_forceRefresh]);
@@ -45,7 +45,7 @@ abstract class UserJsImpl extends UserInfoJsImpl {
       linkAndRetrieveDataWithCredential(AuthCredential credential);
   external PromiseJsImpl<UserJsImpl> linkWithCredential(
       AuthCredential credential);
-  external PromiseJsImpl linkWithPhoneNumber(
+  external PromiseJsImpl<ConfirmationResultJsImpl> linkWithPhoneNumber(
       String phoneNumber, ApplicationVerifierJsImpl applicationVerifier);
   external PromiseJsImpl<UserCredentialJsImpl> linkWithPopup(
       AuthProviderJsImpl provider);
@@ -54,8 +54,9 @@ abstract class UserJsImpl extends UserInfoJsImpl {
       AuthCredential credential);
   external PromiseJsImpl reauthenticateAndRetrieveDataWithCredential(
       AuthCredential credential);
-  external PromiseJsImpl reauthenticateWithPhoneNumber(
-      String phoneNumber, ApplicationVerifierJsImpl applicationVerifier);
+  external PromiseJsImpl<ConfirmationResultJsImpl>
+      reauthenticateWithPhoneNumber(
+          String phoneNumber, ApplicationVerifierJsImpl applicationVerifier);
   external PromiseJsImpl<UserCredentialJsImpl> reauthenticateWithPopup(
       AuthProviderJsImpl provider);
   external PromiseJsImpl reauthenticateWithRedirect(

--- a/lib/src/interop/firebase_interop.dart
+++ b/lib/src/interop/firebase_interop.dart
@@ -36,7 +36,6 @@ abstract class UserJsImpl extends UserInfoJsImpl {
   external bool get isAnonymous;
   external List<UserInfoJsImpl> get providerData;
   external String get refreshToken;
-  external String get phoneNumber;
   external PromiseJsImpl delete();
   @Deprecated('Use `getIdToken` instead.')
   external PromiseJsImpl<String> getToken([bool opt_forceRefresh]);
@@ -75,6 +74,7 @@ abstract class UserJsImpl extends UserInfoJsImpl {
 abstract class UserInfoJsImpl {
   external String get displayName;
   external String get email;
+  external String get phoneNumber;
   external String get photoURL;
   external String get providerId;
   external String get uid;

--- a/lib/src/interop/firebase_interop.dart
+++ b/lib/src/interop/firebase_interop.dart
@@ -37,6 +37,7 @@ abstract class UserJsImpl extends UserInfoJsImpl {
   external List<UserInfoJsImpl> get providerData;
   external String get refreshToken;
   external PromiseJsImpl delete();
+  external String get phoneNumber;
   @Deprecated('Use `getIdToken` instead.')
   external PromiseJsImpl<String> getToken([bool opt_forceRefresh]);
   external PromiseJsImpl<String> getIdToken([bool opt_forceRefresh]);
@@ -44,6 +45,8 @@ abstract class UserJsImpl extends UserInfoJsImpl {
       linkAndRetrieveDataWithCredential(AuthCredential credential);
   external PromiseJsImpl<UserJsImpl> linkWithCredential(
       AuthCredential credential);
+  external PromiseJsImpl linkWithPhoneNumber(
+      String phoneNumber, ApplicationVerifierJsImpl applicationVerifier);
   external PromiseJsImpl<UserCredentialJsImpl> linkWithPopup(
       AuthProviderJsImpl provider);
   external PromiseJsImpl linkWithRedirect(AuthProviderJsImpl provider);
@@ -51,6 +54,8 @@ abstract class UserJsImpl extends UserInfoJsImpl {
       AuthCredential credential);
   external PromiseJsImpl reauthenticateAndRetrieveDataWithCredential(
       AuthCredential credential);
+  external PromiseJsImpl reauthenticateWithPhoneNumber(
+      String phoneNumber, ApplicationVerifierJsImpl applicationVerifier);
   external PromiseJsImpl<UserCredentialJsImpl> reauthenticateWithPopup(
       AuthProviderJsImpl provider);
   external PromiseJsImpl reauthenticateWithRedirect(
@@ -60,6 +65,7 @@ abstract class UserJsImpl extends UserInfoJsImpl {
   external PromiseJsImpl<UserJsImpl> unlink(String providerId);
   external PromiseJsImpl updateEmail(String newEmail);
   external PromiseJsImpl updatePassword(String newPassword);
+  external PromiseJsImpl updatePhoneNumber(AuthCredential phoneCredential);
   external PromiseJsImpl updateProfile(UserProfile profile);
   external Object toJSON();
 }

--- a/test/app_test.html
+++ b/test/app_test.html
@@ -4,7 +4,7 @@
         <title>App Test</title>
     </head>
     <body>
-    <script src="https://www.gstatic.com/firebasejs/4.1.3/firebase.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/4.2.0/firebase.js"></script>
     <script src="packages/test/dart.js"></script>
     <link rel="x-dart-test" href="app_test.dart">
     </body>

--- a/test/auth_test.dart
+++ b/test/auth_test.dart
@@ -540,6 +540,7 @@ void main() {
         expect(userMap, isNotEmpty);
         expect(userMap["displayName"], isNot("Other User"));
         expect(userMap["photoURL"], isNot("http://google.com"));
+        expect(userMap["phoneNumber"], isNull);
       } on FirebaseError catch (e) {
         printException(e);
         rethrow;

--- a/test/auth_test.dart
+++ b/test/auth_test.dart
@@ -357,6 +357,7 @@ void main() {
             userEmail, "janicka");
         expect(user, isNotNull);
         expect(user.email, userEmail);
+        expect(user.phoneNumber, isNull);
       } on FirebaseError catch (e) {
         printException(e);
         rethrow;

--- a/test/auth_test.dart
+++ b/test/auth_test.dart
@@ -330,7 +330,8 @@ void main() {
         // See https://en.wikipedia.org/wiki/JSON_Web_Token
         var split = token.split('.').map((t) {
           // If `t.length` is not a multiple of 4, pad it to the right w/ `=`.
-          var remainder = (4 - t.length % 4);
+          var originalLength = t.length;
+          var remainder = (originalLength / 4).ceil() * 4 - originalLength;
           t = "$t${'='* remainder}";
           return BASE64URL.decode(t);
         }).toList();

--- a/test/auth_test.html
+++ b/test/auth_test.html
@@ -4,7 +4,7 @@
     <title>Authentication Test</title>
 </head>
 <body>
-<script src="https://www.gstatic.com/firebasejs/4.1.3/firebase.js"></script>
+<script src="https://www.gstatic.com/firebasejs/4.2.0/firebase.js"></script>
 <script src="packages/test/dart.js"></script>
 <link rel="x-dart-test" href="auth_test.dart">
 </body>

--- a/test/database_test.html
+++ b/test/database_test.html
@@ -4,7 +4,7 @@
     <title>Database Test</title>
 </head>
 <body>
-<script src="https://www.gstatic.com/firebasejs/4.1.3/firebase.js"></script>
+<script src="https://www.gstatic.com/firebasejs/4.2.0/firebase.js"></script>
 <script src="packages/test/dart.js"></script>
 <link rel="x-dart-test" href="database_test.dart">
 </body>

--- a/test/storage_test.html
+++ b/test/storage_test.html
@@ -4,7 +4,7 @@
     <title>Storage Test</title>
 </head>
 <body>
-<script src="https://www.gstatic.com/firebasejs/4.1.3/firebase.js"></script>
+<script src="https://www.gstatic.com/firebasejs/4.2.0/firebase.js"></script>
 <script src="packages/test/dart.js"></script>
 <link rel="x-dart-test" href="storage_test.dart">
 </body>


### PR DESCRIPTION
@kevmoo 🎉🎉🎉  Phone auth done + new sample + some fixes etc... 🎉🎉🎉

Nice to have: What do you think about the Recaptcha object configuration (e.g. `parameters` param)? Now I am having a Map with recaptcha parameters (which is consistent with JS API) but I dont like it so much - I would prefer to have something like RecaptchaParams object. What do you think?

```dart
var verifier = new fb.RecaptchaVerifier("register", {
      "size": "invisible",
      "callback": (resp) {
        print("reCAPTCHA solved, allow signInWithPhoneNumber.");
      },
      "expired-callback": () {
        print("Response expired. Ask user to solve reCAPTCHA again.");
      }
    });
```

(And I see there is now a new API for Auth state persistence, will take a look and send a new pullreq for this then)


