### PR TITLE
Fix README header anchor to Dart VM and Fuchsia

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   A wrapper over the [Firebase JS API](https://firebase.google.com/docs/reference/js/).
 
 * Dart VM and Fuchsia:
-  [`package:firebase/firebase_io.dart`](https://github.com/firebase/firebase-dart/tree/docs#using-this-package-with-the-dart-vm-and-fuchsia)
+  [`package:firebase/firebase_io.dart`](#using-this-package-with-the-dart-vm-and-fuchsia)
   
   A lightly maintained wrapper over the
   [Firebase Database REST API](https://firebase.google.com/docs/reference/rest/database/).


### PR DESCRIPTION
The [existing link](https://github.com/firebase/firebase-dart/tree/docs#using-this-package-with-the-dart-vm-and-fuchsia) led to a 404.